### PR TITLE
Add package tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,8 @@ migrate_working_dir/
 # The .vscode folder contains launch configuration and tasks you configure in
 # VS Code which you may wish to be included in version control, so this line
 # is commented out by default.
-#.vscode/
+.vscode/
+coverage/
 
 # Flutter/Dart/Pub related
 # Libraries should not include pubspec.lock, per https://dart.dev/guides/libraries/private-files#pubspeclock.

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
+      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
       url: "https://pub.dev"
     source: hosted
-    version: "2.11.0"
+    version: "2.10.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.2.1"
   clock:
     dependency: transitive
     description:
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
+      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.1"
+    version: "1.17.0"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -79,26 +79,26 @@ packages:
     dependency: transitive
     description:
       name: js
-      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
+      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.7"
+    version: "0.6.5"
   lints:
     dependency: transitive
     description:
       name: lints
-      sha256: "0a217c6c989d21039f1498c3ed9f3ed71b354e69873f13a8dfc3c9fe76f1b452"
+      sha256: "5e4a9cd06d447758280a8ac2405101e0e2094d2a1dbdd3756aec3fe7775ba593"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.0.1"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
+      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.15"
+    version: "0.12.13"
   material_color_utilities:
     dependency: transitive
     description:
@@ -111,18 +111,18 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.8.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.8.2"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -134,7 +134,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.4"
+    version: "0.0.5"
   source_span:
     dependency: transitive
     description:
@@ -179,10 +179,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
+      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1"
+    version: "0.4.16"
   vector_math:
     dependency: transitive
     description:
@@ -192,5 +192,5 @@ packages:
     source: hosted
     version: "2.1.4"
 sdks:
-  dart: ">=3.0.5 <4.0.0"
+  dart: ">=2.18.0 <3.0.0"
   flutter: ">=1.17.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -7,7 +7,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: '>=3.0.5 <4.0.0'
+  sdk: '>=2.18.0 <4.0.0'
 
 
 dependencies:

--- a/lib/solar_icons.dart
+++ b/lib/solar_icons.dart
@@ -3,3 +3,4 @@ library solar_icons;
 export 'src/solar_icons_bold.dart';
 export 'src/solar_icons_broken.dart';
 export 'src/solar_icons_outline.dart';
+export 'src/solar_icons_data.dart';

--- a/test/solar_icons_test.dart
+++ b/test/solar_icons_test.dart
@@ -1,1 +1,34 @@
-void main() {}
+import 'package:flutter_test/flutter_test.dart';
+import 'package:solar_icons/solar_icons.dart';
+
+void main() {
+  group(SolarIconsBold, () {
+    test('Test bold icons are generated', () {
+      String fontFamily = 'SolarIconsBold';
+      SolarIconsData icon = SolarIconsData(0xe900, fontFamily: fontFamily);
+      expect(icon, equals(SolarIconsBold.forward));
+      expect(icon.codePoint, 0xe900);
+      expect(icon.fontFamily, SolarIconsBold.forward.fontFamily);
+    });
+  });
+
+  group(SolarIconsOutline, () {
+    test('Test that outline icons are generated', () {
+      String fontFamily = 'SolarIconsOutline';
+      SolarIconsData icon = SolarIconsData(0xe900, fontFamily: fontFamily);
+      expect(icon, equals(SolarIconsOutline.forward));
+      expect(icon.codePoint, 0xe900);
+      expect(icon.fontFamily, SolarIconsOutline.forward.fontFamily);
+    });
+  });
+
+  group(SolarIconsBroken, () {
+    test('Test that broken icons are generated', () {
+      String fontFamily = 'SolarIconsBroken';
+      SolarIconsData icon = SolarIconsData(0xe900, fontFamily: fontFamily);
+      expect(icon, equals(SolarIconsBroken.multipleForwardLeft));
+      expect(icon.codePoint, 0xe900);
+      expect(icon.fontFamily, SolarIconsBroken.multipleForwardLeft.fontFamily);
+    });
+  });
+}


### PR DESCRIPTION
- Set example sdk to dart 2.18 and above. Reason being the package is compatible with all null safety versions but using `'super-parameters'` feature in example needs at least 2.17. Not a package problem though.
- Add tests for bold, outline and broken icons.