### PR TITLE
fix: use `IconData` instead of `SolarIconsData`

### DIFF
--- a/lib/solar_icons.dart
+++ b/lib/solar_icons.dart
@@ -3,4 +3,3 @@ library solar_icons;
 export 'src/solar_icons_bold.dart';
 export 'src/solar_icons_broken.dart';
 export 'src/solar_icons_outline.dart';
-export 'src/solar_icons_data.dart';

--- a/lib/src/solar_icons_bold.dart
+++ b/lib/src/solar_icons_bold.dart
@@ -1,2502 +1,1255 @@
-import 'solar_icons_data.dart';
+import 'package:flutter/widgets.dart';
 
 class SolarIconsBold {
-  SolarIconsBold._();
+  const SolarIconsBold._();
 
-  static const String _fontFamily = 'SolarIconsBold';
+  static const _fontFamily = 'SolarIconsBold';
 
-  static const SolarIconsData forward =
-      SolarIconsData(0xe900, fontFamily: _fontFamily);
-  static const SolarIconsData letterOpened =
-      SolarIconsData(0xe901, fontFamily: _fontFamily);
-  static const SolarIconsData letterUnread =
-      SolarIconsData(0xe902, fontFamily: _fontFamily);
-  static const SolarIconsData letter =
-      SolarIconsData(0xe903, fontFamily: _fontFamily);
-  static const SolarIconsData multipleForwardLeft =
-      SolarIconsData(0xe904, fontFamily: _fontFamily);
-  static const SolarIconsData multipleForwardRight =
-      SolarIconsData(0xe905, fontFamily: _fontFamily);
-  static const SolarIconsData paperclip2 =
-      SolarIconsData(0xe906, fontFamily: _fontFamily);
-  static const SolarIconsData paperclipRounded2 =
-      SolarIconsData(0xe907, fontFamily: _fontFamily);
-  static const SolarIconsData paperclipRounded =
-      SolarIconsData(0xe908, fontFamily: _fontFamily);
-  static const SolarIconsData paperclip =
-      SolarIconsData(0xe909, fontFamily: _fontFamily);
-  static const SolarIconsData pen2 =
-      SolarIconsData(0xe90a, fontFamily: _fontFamily);
-  static const SolarIconsData penNewRound =
-      SolarIconsData(0xe90b, fontFamily: _fontFamily);
-  static const SolarIconsData penNewSquare =
-      SolarIconsData(0xe90c, fontFamily: _fontFamily);
-  static const SolarIconsData pen =
-      SolarIconsData(0xe90d, fontFamily: _fontFamily);
-  static const SolarIconsData plain2 =
-      SolarIconsData(0xe90e, fontFamily: _fontFamily);
-  static const SolarIconsData plain3 =
-      SolarIconsData(0xe90f, fontFamily: _fontFamily);
-  static const SolarIconsData plain =
-      SolarIconsData(0xe910, fontFamily: _fontFamily);
-  static const SolarIconsData squareForward =
-      SolarIconsData(0xe911, fontFamily: _fontFamily);
-  static const SolarIconsData squareShareLine =
-      SolarIconsData(0xe912, fontFamily: _fontFamily);
-  static const SolarIconsData chatDots =
-      SolarIconsData(0xe913, fontFamily: _fontFamily);
-  static const SolarIconsData chatLine =
-      SolarIconsData(0xe914, fontFamily: _fontFamily);
-  static const SolarIconsData chatRoundCall =
-      SolarIconsData(0xe915, fontFamily: _fontFamily);
-  static const SolarIconsData chatRoundCheck =
-      SolarIconsData(0xe916, fontFamily: _fontFamily);
-  static const SolarIconsData chatRoundLike =
-      SolarIconsData(0xe917, fontFamily: _fontFamily);
-  static const SolarIconsData chatRoundUnread =
-      SolarIconsData(0xe918, fontFamily: _fontFamily);
-  static const SolarIconsData chatRoundVideo =
-      SolarIconsData(0xe919, fontFamily: _fontFamily);
-  static const SolarIconsData chatSquareArrow =
-      SolarIconsData(0xe91a, fontFamily: _fontFamily);
-  static const SolarIconsData chatSquareCall =
-      SolarIconsData(0xe91b, fontFamily: _fontFamily);
-  static const SolarIconsData chatSquareCheck =
-      SolarIconsData(0xe91c, fontFamily: _fontFamily);
-  static const SolarIconsData chatSquareCode =
-      SolarIconsData(0xe91d, fontFamily: _fontFamily);
-  static const SolarIconsData chatSquareLike =
-      SolarIconsData(0xe91e, fontFamily: _fontFamily);
-  static const SolarIconsData chatSquare =
-      SolarIconsData(0xe91f, fontFamily: _fontFamily);
-  static const SolarIconsData chatUnread =
-      SolarIconsData(0xe920, fontFamily: _fontFamily);
-  static const SolarIconsData chatRead =
-      SolarIconsData(0xe921, fontFamily: _fontFamily);
-  static const SolarIconsData dialog2 =
-      SolarIconsData(0xe922, fontFamily: _fontFamily);
-  static const SolarIconsData inboxArchive =
-      SolarIconsData(0xe923, fontFamily: _fontFamily);
-  static const SolarIconsData inboxIn =
-      SolarIconsData(0xe924, fontFamily: _fontFamily);
-  static const SolarIconsData inboxLine =
-      SolarIconsData(0xe925, fontFamily: _fontFamily);
-  static const SolarIconsData inboxOut =
-      SolarIconsData(0xe926, fontFamily: _fontFamily);
-  static const SolarIconsData inboxUnread =
-      SolarIconsData(0xe927, fontFamily: _fontFamily);
-  static const SolarIconsData inbox =
-      SolarIconsData(0xe928, fontFamily: _fontFamily);
-  static const SolarIconsData mailbox =
-      SolarIconsData(0xe929, fontFamily: _fontFamily);
-  static const SolarIconsData unread =
-      SolarIconsData(0xe92a, fontFamily: _fontFamily);
-  static const SolarIconsData chatRoundDots =
-      SolarIconsData(0xe92b, fontFamily: _fontFamily);
-  static const SolarIconsData chatRoundLine =
-      SolarIconsData(0xe92f, fontFamily: _fontFamily);
-  static const SolarIconsData chatRoundMoney =
-      SolarIconsData(0xe930, fontFamily: _fontFamily);
-  static const SolarIconsData chatRound =
-      SolarIconsData(0xe931, fontFamily: _fontFamily);
-  static const SolarIconsData dialog =
-      SolarIconsData(0xe932, fontFamily: _fontFamily);
-  static const SolarIconsData altArrowLeft =
-      SolarIconsData(0xe933, fontFamily: _fontFamily);
-  static const SolarIconsData altArrowRight =
-      SolarIconsData(0xe934, fontFamily: _fontFamily);
-  static const SolarIconsData refreshCircle =
-      SolarIconsData(0xe935, fontFamily: _fontFamily);
-  static const SolarIconsData refreshSquare =
-      SolarIconsData(0xe936, fontFamily: _fontFamily);
-  static const SolarIconsData refresh =
-      SolarIconsData(0xe937, fontFamily: _fontFamily);
-  static const SolarIconsData restartCircle =
-      SolarIconsData(0xe938, fontFamily: _fontFamily);
-  static const SolarIconsData restartSquare =
-      SolarIconsData(0xe939, fontFamily: _fontFamily);
-  static const SolarIconsData restart =
-      SolarIconsData(0xe93a, fontFamily: _fontFamily);
-  static const SolarIconsData altArrowDown =
-      SolarIconsData(0xe93b, fontFamily: _fontFamily);
-  static const SolarIconsData altArrowUp =
-      SolarIconsData(0xe93c, fontFamily: _fontFamily);
-  static const SolarIconsData arrowDown =
-      SolarIconsData(0xe93d, fontFamily: _fontFamily);
-  static const SolarIconsData arrowLeftDown =
-      SolarIconsData(0xe93e, fontFamily: _fontFamily);
-  static const SolarIconsData arrowLeftUp =
-      SolarIconsData(0xe93f, fontFamily: _fontFamily);
-  static const SolarIconsData arrowLeft =
-      SolarIconsData(0xe940, fontFamily: _fontFamily);
-  static const SolarIconsData arrowRightDown =
-      SolarIconsData(0xe941, fontFamily: _fontFamily);
-  static const SolarIconsData arrowRightUp =
-      SolarIconsData(0xe942, fontFamily: _fontFamily);
-  static const SolarIconsData arrowRight =
-      SolarIconsData(0xe943, fontFamily: _fontFamily);
-  static const SolarIconsData arrowUp =
-      SolarIconsData(0xe944, fontFamily: _fontFamily);
-  static const SolarIconsData doubleAltArrowDown =
-      SolarIconsData(0xe945, fontFamily: _fontFamily);
-  static const SolarIconsData doubleAltArrowLeft =
-      SolarIconsData(0xe946, fontFamily: _fontFamily);
-  static const SolarIconsData doubleAltArrowRight =
-      SolarIconsData(0xe947, fontFamily: _fontFamily);
-  static const SolarIconsData doubleAltArrowUp =
-      SolarIconsData(0xe948, fontFamily: _fontFamily);
-  static const SolarIconsData roundAltArrowDown =
-      SolarIconsData(0xe949, fontFamily: _fontFamily);
-  static const SolarIconsData roundAltArrowUp =
-      SolarIconsData(0xe94a, fontFamily: _fontFamily);
-  static const SolarIconsData roundArrowRightUp =
-      SolarIconsData(0xe94b, fontFamily: _fontFamily);
-  static const SolarIconsData roundDoubleAltArrowLeft =
-      SolarIconsData(0xe94c, fontFamily: _fontFamily);
-  static const SolarIconsData roundDoubleAltArrowRight =
-      SolarIconsData(0xe94d, fontFamily: _fontFamily);
-  static const SolarIconsData roundDoubleAltArrowUp =
-      SolarIconsData(0xe94e, fontFamily: _fontFamily);
-  static const SolarIconsData roundSortHorizontal =
-      SolarIconsData(0xe94f, fontFamily: _fontFamily);
-  static const SolarIconsData roundTransferDiagonal =
-      SolarIconsData(0xe950, fontFamily: _fontFamily);
-  static const SolarIconsData roundTransferVertical =
-      SolarIconsData(0xe951, fontFamily: _fontFamily);
-  static const SolarIconsData sortHorizontal =
-      SolarIconsData(0xe952, fontFamily: _fontFamily);
-  static const SolarIconsData sortVertical =
-      SolarIconsData(0xe953, fontFamily: _fontFamily);
-  static const SolarIconsData transferHorizontal =
-      SolarIconsData(0xe954, fontFamily: _fontFamily);
-  static const SolarIconsData transferVertical =
-      SolarIconsData(0xe955, fontFamily: _fontFamily);
-  static const SolarIconsData roundAltArrowLeft =
-      SolarIconsData(0xe956, fontFamily: _fontFamily);
-  static const SolarIconsData roundAltArrowRight =
-      SolarIconsData(0xe957, fontFamily: _fontFamily);
-  static const SolarIconsData roundArrowDown =
-      SolarIconsData(0xe958, fontFamily: _fontFamily);
-  static const SolarIconsData roundArrowLeftDown =
-      SolarIconsData(0xe959, fontFamily: _fontFamily);
-  static const SolarIconsData roundArrowLeftUp =
-      SolarIconsData(0xe95a, fontFamily: _fontFamily);
-  static const SolarIconsData roundArrowLeft =
-      SolarIconsData(0xe95b, fontFamily: _fontFamily);
-  static const SolarIconsData roundArrowRightDown =
-      SolarIconsData(0xe95c, fontFamily: _fontFamily);
-  static const SolarIconsData roundArrowRight =
-      SolarIconsData(0xe95d, fontFamily: _fontFamily);
-  static const SolarIconsData roundArrowUp =
-      SolarIconsData(0xe95e, fontFamily: _fontFamily);
-  static const SolarIconsData roundDoubleAltArrowDown =
-      SolarIconsData(0xe95f, fontFamily: _fontFamily);
-  static const SolarIconsData roundSortVertical =
-      SolarIconsData(0xe960, fontFamily: _fontFamily);
-  static const SolarIconsData roundTransferHorizontal =
-      SolarIconsData(0xe961, fontFamily: _fontFamily);
-  static const SolarIconsData squareAltArrowDown =
-      SolarIconsData(0xe962, fontFamily: _fontFamily);
-  static const SolarIconsData squareArrowDown =
-      SolarIconsData(0xe963, fontFamily: _fontFamily);
-  static const SolarIconsData squareArrowLeftDown =
-      SolarIconsData(0xe964, fontFamily: _fontFamily);
-  static const SolarIconsData squareArrowLeftUp =
-      SolarIconsData(0xe965, fontFamily: _fontFamily);
-  static const SolarIconsData squareArrowLeft =
-      SolarIconsData(0xe966, fontFamily: _fontFamily);
-  static const SolarIconsData squareArrowRightDown =
-      SolarIconsData(0xe967, fontFamily: _fontFamily);
-  static const SolarIconsData squareArrowRightUp =
-      SolarIconsData(0xe968, fontFamily: _fontFamily);
-  static const SolarIconsData squareArrowRight =
-      SolarIconsData(0xe969, fontFamily: _fontFamily);
-  static const SolarIconsData squareArrowUp =
-      SolarIconsData(0xe96a, fontFamily: _fontFamily);
-  static const SolarIconsData squareSortHorizontal =
-      SolarIconsData(0xe96b, fontFamily: _fontFamily);
-  static const SolarIconsData squareSortVertical =
-      SolarIconsData(0xe96c, fontFamily: _fontFamily);
-  static const SolarIconsData squareTransferHorizontal =
-      SolarIconsData(0xe96d, fontFamily: _fontFamily);
-  static const SolarIconsData squareTransferVertical =
-      SolarIconsData(0xe96e, fontFamily: _fontFamily);
-  static const SolarIconsData squareAltArrowLeft =
-      SolarIconsData(0xe96f, fontFamily: _fontFamily);
-  static const SolarIconsData squareAltArrowRight =
-      SolarIconsData(0xe970, fontFamily: _fontFamily);
-  static const SolarIconsData squareAltArrowUp =
-      SolarIconsData(0xe971, fontFamily: _fontFamily);
-  static const SolarIconsData squareDoubleAltArrowRight =
-      SolarIconsData(0xe972, fontFamily: _fontFamily);
-  static const SolarIconsData squareDoubleAltArrowDown =
-      SolarIconsData(0xe973, fontFamily: _fontFamily);
-  static const SolarIconsData squareDoubleAltArrowLeft =
-      SolarIconsData(0xe974, fontFamily: _fontFamily);
-  static const SolarIconsData squareDoubleAltArrowUp =
-      SolarIconsData(0xe975, fontFamily: _fontFamily);
-  static const SolarIconsData branchingPathsDown =
-      SolarIconsData(0xe976, fontFamily: _fontFamily);
-  static const SolarIconsData branchingPathsUp =
-      SolarIconsData(0xe977, fontFamily: _fontFamily);
-  static const SolarIconsData compassBig =
-      SolarIconsData(0xe978, fontFamily: _fontFamily);
-  static const SolarIconsData globus =
-      SolarIconsData(0xe979, fontFamily: _fontFamily);
-  static const SolarIconsData gps =
-      SolarIconsData(0xe97a, fontFamily: _fontFamily);
-  static const SolarIconsData mapArrowLeft =
-      SolarIconsData(0xe97b, fontFamily: _fontFamily);
-  static const SolarIconsData mapArrowSquare =
-      SolarIconsData(0xe97c, fontFamily: _fontFamily);
-  static const SolarIconsData pointOnMapPerspective =
-      SolarIconsData(0xe97d, fontFamily: _fontFamily);
-  static const SolarIconsData radar2 =
-      SolarIconsData(0xe97e, fontFamily: _fontFamily);
-  static const SolarIconsData radar =
-      SolarIconsData(0xe97f, fontFamily: _fontFamily);
-  static const SolarIconsData route =
-      SolarIconsData(0xe980, fontFamily: _fontFamily);
-  static const SolarIconsData routing2 =
-      SolarIconsData(0xe981, fontFamily: _fontFamily);
-  static const SolarIconsData routing3 =
-      SolarIconsData(0xe982, fontFamily: _fontFamily);
-  static const SolarIconsData routing =
-      SolarIconsData(0xe983, fontFamily: _fontFamily);
-  static const SolarIconsData signpost2 =
-      SolarIconsData(0xe984, fontFamily: _fontFamily);
-  static const SolarIconsData signpost =
-      SolarIconsData(0xe985, fontFamily: _fontFamily);
-  static const SolarIconsData streetsMapPoint =
-      SolarIconsData(0xe986, fontFamily: _fontFamily);
-  static const SolarIconsData streetsNavigation =
-      SolarIconsData(0xe987, fontFamily: _fontFamily);
-  static const SolarIconsData streets =
-      SolarIconsData(0xe988, fontFamily: _fontFamily);
-  static const SolarIconsData compassSquare =
-      SolarIconsData(0xe989, fontFamily: _fontFamily);
-  static const SolarIconsData compass =
-      SolarIconsData(0xe98a, fontFamily: _fontFamily);
-  static const SolarIconsData global =
-      SolarIconsData(0xe98b, fontFamily: _fontFamily);
-  static const SolarIconsData mapArrowDown =
-      SolarIconsData(0xe98c, fontFamily: _fontFamily);
-  static const SolarIconsData mapArrowRight =
-      SolarIconsData(0xe98d, fontFamily: _fontFamily);
-  static const SolarIconsData mapArrowUp =
-      SolarIconsData(0xe98e, fontFamily: _fontFamily);
-  static const SolarIconsData mapPointAdd =
-      SolarIconsData(0xe98f, fontFamily: _fontFamily);
-  static const SolarIconsData mapPointFavourite =
-      SolarIconsData(0xe990, fontFamily: _fontFamily);
-  static const SolarIconsData mapPointHospital =
-      SolarIconsData(0xe991, fontFamily: _fontFamily);
-  static const SolarIconsData mapPointRemove =
-      SolarIconsData(0xe992, fontFamily: _fontFamily);
-  static const SolarIconsData mapPointRotate =
-      SolarIconsData(0xe993, fontFamily: _fontFamily);
-  static const SolarIconsData mapPointSchool =
-      SolarIconsData(0xe994, fontFamily: _fontFamily);
-  static const SolarIconsData mapPointSearch =
-      SolarIconsData(0xe995, fontFamily: _fontFamily);
-  static const SolarIconsData mapPointWave =
-      SolarIconsData(0xe996, fontFamily: _fontFamily);
-  static const SolarIconsData mapPoint =
-      SolarIconsData(0xe997, fontFamily: _fontFamily);
-  static const SolarIconsData map =
-      SolarIconsData(0xe998, fontFamily: _fontFamily);
-  static const SolarIconsData peopleNearby =
-      SolarIconsData(0xe999, fontFamily: _fontFamily);
-  static const SolarIconsData pointOnMap =
-      SolarIconsData(0xe99a, fontFamily: _fontFamily);
-  static const SolarIconsData cameraAdd =
-      SolarIconsData(0xe99b, fontFamily: _fontFamily);
-  static const SolarIconsData cameraMinimalistic =
-      SolarIconsData(0xe99c, fontFamily: _fontFamily);
-  static const SolarIconsData cameraRotate =
-      SolarIconsData(0xe99d, fontFamily: _fontFamily);
-  static const SolarIconsData cameraSquare =
-      SolarIconsData(0xe99e, fontFamily: _fontFamily);
-  static const SolarIconsData camera =
-      SolarIconsData(0xe99f, fontFamily: _fontFamily);
-  static const SolarIconsData fullScreenCircle =
-      SolarIconsData(0xe9a0, fontFamily: _fontFamily);
-  static const SolarIconsData fullScreenSquare =
-      SolarIconsData(0xe9a1, fontFamily: _fontFamily);
-  static const SolarIconsData fullScreen =
-      SolarIconsData(0xe9a2, fontFamily: _fontFamily);
-  static const SolarIconsData galleryCircle =
-      SolarIconsData(0xe9a3, fontFamily: _fontFamily);
-  static const SolarIconsData galleryRound =
-      SolarIconsData(0xe9a4, fontFamily: _fontFamily);
-  static const SolarIconsData pip2 =
-      SolarIconsData(0xe9a5, fontFamily: _fontFamily);
-  static const SolarIconsData pip =
-      SolarIconsData(0xe9a6, fontFamily: _fontFamily);
-  static const SolarIconsData playbackSpeed =
-      SolarIconsData(0xe9a7, fontFamily: _fontFamily);
-  static const SolarIconsData quitFullScreenCircle =
-      SolarIconsData(0xe9a8, fontFamily: _fontFamily);
-  static const SolarIconsData quitFullScreenSquare =
-      SolarIconsData(0xe9a9, fontFamily: _fontFamily);
-  static const SolarIconsData quitFullScreen =
-      SolarIconsData(0xe9aa, fontFamily: _fontFamily);
-  static const SolarIconsData quitPIP =
-      SolarIconsData(0xe9ab, fontFamily: _fontFamily);
-  static const SolarIconsData reel2 =
-      SolarIconsData(0xe9ac, fontFamily: _fontFamily);
-  static const SolarIconsData reel =
-      SolarIconsData(0xe9ad, fontFamily: _fontFamily);
-  static const SolarIconsData rewindBackCircle =
-      SolarIconsData(0xe9ae, fontFamily: _fontFamily);
-  static const SolarIconsData rewindForwardCircle =
-      SolarIconsData(0xe9af, fontFamily: _fontFamily);
-  static const SolarIconsData shuffle =
-      SolarIconsData(0xe9b0, fontFamily: _fontFamily);
-  static const SolarIconsData stopCircle =
-      SolarIconsData(0xe9b1, fontFamily: _fontFamily);
-  static const SolarIconsData stream =
-      SolarIconsData(0xe9b2, fontFamily: _fontFamily);
-  static const SolarIconsData toPIP =
-      SolarIconsData(0xe9b3, fontFamily: _fontFamily);
-  static const SolarIconsData videocameraAdd =
-      SolarIconsData(0xe9b4, fontFamily: _fontFamily);
-  static const SolarIconsData videocameraRecord =
-      SolarIconsData(0xe9b5, fontFamily: _fontFamily);
-  static const SolarIconsData videocamera =
-      SolarIconsData(0xe9b6, fontFamily: _fontFamily);
-  static const SolarIconsData clapperboardEdit =
-      SolarIconsData(0xe9b7, fontFamily: _fontFamily);
-  static const SolarIconsData clapperboardText =
-      SolarIconsData(0xe9b8, fontFamily: _fontFamily);
-  static const SolarIconsData galleryCheck =
-      SolarIconsData(0xe9b9, fontFamily: _fontFamily);
-  static const SolarIconsData galleryEdit =
-      SolarIconsData(0xe9ba, fontFamily: _fontFamily);
-  static const SolarIconsData galleryFavourite =
-      SolarIconsData(0xe9bb, fontFamily: _fontFamily);
-  static const SolarIconsData galleryRemove =
-      SolarIconsData(0xe9bc, fontFamily: _fontFamily);
-  static const SolarIconsData musicLibrary2 =
-      SolarIconsData(0xe9bd, fontFamily: _fontFamily);
-  static const SolarIconsData musicLibrary =
-      SolarIconsData(0xe9be, fontFamily: _fontFamily);
-  static const SolarIconsData musicNoteSlider2 =
-      SolarIconsData(0xe9bf, fontFamily: _fontFamily);
-  static const SolarIconsData musicNoteSlider =
-      SolarIconsData(0xe9c0, fontFamily: _fontFamily);
-  static const SolarIconsData musicNotes =
-      SolarIconsData(0xe9c1, fontFamily: _fontFamily);
-  static const SolarIconsData panorama =
-      SolarIconsData(0xe9c2, fontFamily: _fontFamily);
-  static const SolarIconsData pauseCircle =
-      SolarIconsData(0xe9c3, fontFamily: _fontFamily);
-  static const SolarIconsData playCircle =
-      SolarIconsData(0xe9c4, fontFamily: _fontFamily);
-  static const SolarIconsData podcast =
-      SolarIconsData(0xe9c5, fontFamily: _fontFamily);
-  static const SolarIconsData rewind10SecondsBack =
-      SolarIconsData(0xe9c6, fontFamily: _fontFamily);
-  static const SolarIconsData rewind10SecondsForward =
-      SolarIconsData(0xe9c7, fontFamily: _fontFamily);
-  static const SolarIconsData rewindBack =
-      SolarIconsData(0xe9c8, fontFamily: _fontFamily);
-  static const SolarIconsData skipNext =
-      SolarIconsData(0xe9c9, fontFamily: _fontFamily);
-  static const SolarIconsData skipPrevious =
-      SolarIconsData(0xe9ca, fontFamily: _fontFamily);
-  static const SolarIconsData uploadTrack2 =
-      SolarIconsData(0xe9cb, fontFamily: _fontFamily);
-  static const SolarIconsData uploadTrack =
-      SolarIconsData(0xe9cc, fontFamily: _fontFamily);
-  static const SolarIconsData videoFrame2 =
-      SolarIconsData(0xe9cd, fontFamily: _fontFamily);
-  static const SolarIconsData videoFramePlayHorizontal =
-      SolarIconsData(0xe9ce, fontFamily: _fontFamily);
-  static const SolarIconsData videoFramePlayVertical =
-      SolarIconsData(0xe9cf, fontFamily: _fontFamily);
-  static const SolarIconsData volumeCross =
-      SolarIconsData(0xe9d0, fontFamily: _fontFamily);
-  static const SolarIconsData wallpaper =
-      SolarIconsData(0xe9d1, fontFamily: _fontFamily);
-  static const SolarIconsData clapperboardOpenPlay =
-      SolarIconsData(0xe9d2, fontFamily: _fontFamily);
-  static const SolarIconsData galleryAdd =
-      SolarIconsData(0xe9d3, fontFamily: _fontFamily);
-  static const SolarIconsData galleryDownload =
-      SolarIconsData(0xe9d4, fontFamily: _fontFamily);
-  static const SolarIconsData gallerySend =
-      SolarIconsData(0xe9d5, fontFamily: _fontFamily);
-  static const SolarIconsData galleryWide =
-      SolarIconsData(0xe9d6, fontFamily: _fontFamily);
-  static const SolarIconsData microphoneLarge =
-      SolarIconsData(0xe9d7, fontFamily: _fontFamily);
-  static const SolarIconsData microphone =
-      SolarIconsData(0xe9d8, fontFamily: _fontFamily);
-  static const SolarIconsData musicNote2 =
-      SolarIconsData(0xe9d9, fontFamily: _fontFamily);
-  static const SolarIconsData musicNote =
-      SolarIconsData(0xe9da, fontFamily: _fontFamily);
-  static const SolarIconsData pause =
-      SolarIconsData(0xe9db, fontFamily: _fontFamily);
-  static const SolarIconsData playStream =
-      SolarIconsData(0xe9dc, fontFamily: _fontFamily);
-  static const SolarIconsData play =
-      SolarIconsData(0xe9dd, fontFamily: _fontFamily);
-  static const SolarIconsData repeatOneMinimalistic =
-      SolarIconsData(0xe9de, fontFamily: _fontFamily);
-  static const SolarIconsData rewind15SecondsBack =
-      SolarIconsData(0xe9df, fontFamily: _fontFamily);
-  static const SolarIconsData rewind15SecondsForward =
-      SolarIconsData(0xe9e0, fontFamily: _fontFamily);
-  static const SolarIconsData rewindForward =
-      SolarIconsData(0xe9e1, fontFamily: _fontFamily);
-  static const SolarIconsData soundwaveCircle =
-      SolarIconsData(0xe9e2, fontFamily: _fontFamily);
-  static const SolarIconsData videoFrameCut2 =
-      SolarIconsData(0xe9e3, fontFamily: _fontFamily);
-  static const SolarIconsData videoFrameReplace =
-      SolarIconsData(0xe9e4, fontFamily: _fontFamily);
-  static const SolarIconsData videoLibrary =
-      SolarIconsData(0xe9e5, fontFamily: _fontFamily);
-  static const SolarIconsData vinyl =
-      SolarIconsData(0xe9e6, fontFamily: _fontFamily);
-  static const SolarIconsData volume =
-      SolarIconsData(0xe9e7, fontFamily: _fontFamily);
-  static const SolarIconsData album =
-      SolarIconsData(0xe9e8, fontFamily: _fontFamily);
-  static const SolarIconsData clapperboardOpen =
-      SolarIconsData(0xe9e9, fontFamily: _fontFamily);
-  static const SolarIconsData clapperboardPlay =
-      SolarIconsData(0xe9ea, fontFamily: _fontFamily);
-  static const SolarIconsData galleryMinimalistic =
-      SolarIconsData(0xe9eb, fontFamily: _fontFamily);
-  static const SolarIconsData library =
-      SolarIconsData(0xe9ec, fontFamily: _fontFamily);
-  static const SolarIconsData microphone2 =
-      SolarIconsData(0xe9ed, fontFamily: _fontFamily);
-  static const SolarIconsData microphone3 =
-      SolarIconsData(0xe9ee, fontFamily: _fontFamily);
-  static const SolarIconsData musicNote3 =
-      SolarIconsData(0xe9ef, fontFamily: _fontFamily);
-  static const SolarIconsData muted =
-      SolarIconsData(0xe9f0, fontFamily: _fontFamily);
-  static const SolarIconsData recordCircle =
-      SolarIconsData(0xe9f1, fontFamily: _fontFamily);
-  static const SolarIconsData record =
-      SolarIconsData(0xe9f2, fontFamily: _fontFamily);
-  static const SolarIconsData repeatOne =
-      SolarIconsData(0xe9f3, fontFamily: _fontFamily);
-  static const SolarIconsData repeat =
-      SolarIconsData(0xe9f4, fontFamily: _fontFamily);
-  static const SolarIconsData rewind5SecondsForward =
-      SolarIconsData(0xe9f5, fontFamily: _fontFamily);
-  static const SolarIconsData soundwaveSquare =
-      SolarIconsData(0xe9f6, fontFamily: _fontFamily);
-  static const SolarIconsData soundwave =
-      SolarIconsData(0xe9f7, fontFamily: _fontFamily);
-  static const SolarIconsData stop =
-      SolarIconsData(0xe9f8, fontFamily: _fontFamily);
-  static const SolarIconsData videoFrameCut =
-      SolarIconsData(0xe9f9, fontFamily: _fontFamily);
-  static const SolarIconsData vinylRecord =
-      SolarIconsData(0xe9fa, fontFamily: _fontFamily);
-  static const SolarIconsData volumeLoud =
-      SolarIconsData(0xe9fb, fontFamily: _fontFamily);
-  static const SolarIconsData volumeSmall =
-      SolarIconsData(0xe9fc, fontFamily: _fontFamily);
-  static const SolarIconsData clapperboard =
-      SolarIconsData(0xe9fd, fontFamily: _fontFamily);
-  static const SolarIconsData gallery =
-      SolarIconsData(0xe9fe, fontFamily: _fontFamily);
-  static const SolarIconsData musicNote4 =
-      SolarIconsData(0xe9ff, fontFamily: _fontFamily);
-  static const SolarIconsData rewind5SecondsBack =
-      SolarIconsData(0xea00, fontFamily: _fontFamily);
-  static const SolarIconsData videoFrame =
-      SolarIconsData(0xea01, fontFamily: _fontFamily);
-  static const SolarIconsData billCheck =
-      SolarIconsData(0xea02, fontFamily: _fontFamily);
-  static const SolarIconsData billCross =
-      SolarIconsData(0xea03, fontFamily: _fontFamily);
-  static const SolarIconsData billList =
-      SolarIconsData(0xea04, fontFamily: _fontFamily);
-  static const SolarIconsData bill =
-      SolarIconsData(0xea05, fontFamily: _fontFamily);
-  static const SolarIconsData cashOut =
-      SolarIconsData(0xea06, fontFamily: _fontFamily);
-  static const SolarIconsData moneyBag =
-      SolarIconsData(0xea07, fontFamily: _fontFamily);
-  static const SolarIconsData safe2 =
-      SolarIconsData(0xea08, fontFamily: _fontFamily);
-  static const SolarIconsData banknote2 =
-      SolarIconsData(0xea09, fontFamily: _fontFamily);
-  static const SolarIconsData banknote =
-      SolarIconsData(0xea0a, fontFamily: _fontFamily);
-  static const SolarIconsData card2 =
-      SolarIconsData(0xea0b, fontFamily: _fontFamily);
-  static const SolarIconsData cardReceive =
-      SolarIconsData(0xea0c, fontFamily: _fontFamily);
-  static const SolarIconsData cardSearch =
-      SolarIconsData(0xea0d, fontFamily: _fontFamily);
-  static const SolarIconsData cardSend =
-      SolarIconsData(0xea0e, fontFamily: _fontFamily);
-  static const SolarIconsData cardTransfer =
-      SolarIconsData(0xea0f, fontFamily: _fontFamily);
-  static const SolarIconsData card =
-      SolarIconsData(0xea10, fontFamily: _fontFamily);
-  static const SolarIconsData cardholder =
-      SolarIconsData(0xea14, fontFamily: _fontFamily);
-  static const SolarIconsData dollarMinimalistic =
-      SolarIconsData(0xea15, fontFamily: _fontFamily);
-  static const SolarIconsData dollar =
-      SolarIconsData(0xea16, fontFamily: _fontFamily);
-  static const SolarIconsData euro =
-      SolarIconsData(0xea17, fontFamily: _fontFamily);
-  static const SolarIconsData ruble =
-      SolarIconsData(0xea18, fontFamily: _fontFamily);
-  static const SolarIconsData safeCircle =
-      SolarIconsData(0xea19, fontFamily: _fontFamily);
-  static const SolarIconsData safeSquare =
-      SolarIconsData(0xea1a, fontFamily: _fontFamily);
-  static const SolarIconsData saleSquare =
-      SolarIconsData(0xea1b, fontFamily: _fontFamily);
-  static const SolarIconsData sale =
-      SolarIconsData(0xea1c, fontFamily: _fontFamily);
-  static const SolarIconsData tagHorizontal =
-      SolarIconsData(0xea1d, fontFamily: _fontFamily);
-  static const SolarIconsData tagPrice =
-      SolarIconsData(0xea1e, fontFamily: _fontFamily);
-  static const SolarIconsData tag =
-      SolarIconsData(0xea1f, fontFamily: _fontFamily);
-  static const SolarIconsData tickerStar =
-      SolarIconsData(0xea20, fontFamily: _fontFamily);
-  static const SolarIconsData ticketSale =
-      SolarIconsData(0xea21, fontFamily: _fontFamily);
-  static const SolarIconsData ticket =
-      SolarIconsData(0xea22, fontFamily: _fontFamily);
-  static const SolarIconsData verifiedCheck =
-      SolarIconsData(0xea23, fontFamily: _fontFamily);
-  static const SolarIconsData wadOfMoney =
-      SolarIconsData(0xea24, fontFamily: _fontFamily);
-  static const SolarIconsData wallet2 =
-      SolarIconsData(0xea25, fontFamily: _fontFamily);
-  static const SolarIconsData walletMoney =
-      SolarIconsData(0xea26, fontFamily: _fontFamily);
-  static const SolarIconsData wallet =
-      SolarIconsData(0xea27, fontFamily: _fontFamily);
-  static const SolarIconsData headphonesRoundSound =
-      SolarIconsData(0xea28, fontFamily: _fontFamily);
-  static const SolarIconsData headphonesRound =
-      SolarIconsData(0xea29, fontFamily: _fontFamily);
-  static const SolarIconsData headphonesSquareSound =
-      SolarIconsData(0xea2a, fontFamily: _fontFamily);
-  static const SolarIconsData headphonesSquare =
-      SolarIconsData(0xea2b, fontFamily: _fontFamily);
-  static const SolarIconsData mouseCircle =
-      SolarIconsData(0xea2c, fontFamily: _fontFamily);
-  static const SolarIconsData mouseMinimalistic =
-      SolarIconsData(0xea2d, fontFamily: _fontFamily);
-  static const SolarIconsData mouse =
-      SolarIconsData(0xea2e, fontFamily: _fontFamily);
-  static const SolarIconsData server2 =
-      SolarIconsData(0xea2f, fontFamily: _fontFamily);
-  static const SolarIconsData serverMinimalistic =
-      SolarIconsData(0xea30, fontFamily: _fontFamily);
-  static const SolarIconsData serverPath =
-      SolarIconsData(0xea31, fontFamily: _fontFamily);
-  static const SolarIconsData serverSquareCloud =
-      SolarIconsData(0xea32, fontFamily: _fontFamily);
-  static const SolarIconsData serverSquareUpdate =
-      SolarIconsData(0xea33, fontFamily: _fontFamily);
-  static const SolarIconsData serverSquare =
-      SolarIconsData(0xea34, fontFamily: _fontFamily);
-  static const SolarIconsData server =
-      SolarIconsData(0xea35, fontFamily: _fontFamily);
-  static const SolarIconsData smartphoneRotateAngle =
-      SolarIconsData(0xea36, fontFamily: _fontFamily);
-  static const SolarIconsData tablet =
-      SolarIconsData(0xea37, fontFamily: _fontFamily);
-  static const SolarIconsData cloudStorage =
-      SolarIconsData(0xea38, fontFamily: _fontFamily);
-  static const SolarIconsData devices =
-      SolarIconsData(0xea39, fontFamily: _fontFamily);
-  static const SolarIconsData diskette =
-      SolarIconsData(0xea3a, fontFamily: _fontFamily);
-  static const SolarIconsData flashDrive =
-      SolarIconsData(0xea3b, fontFamily: _fontFamily);
-  static const SolarIconsData gamepadCharge =
-      SolarIconsData(0xea3c, fontFamily: _fontFamily);
-  static const SolarIconsData gamepadMinimalistic =
-      SolarIconsData(0xea3d, fontFamily: _fontFamily);
-  static const SolarIconsData gamepadNoCharge =
-      SolarIconsData(0xea3e, fontFamily: _fontFamily);
-  static const SolarIconsData gamepadOld =
-      SolarIconsData(0xea3f, fontFamily: _fontFamily);
-  static const SolarIconsData gamepad =
-      SolarIconsData(0xea40, fontFamily: _fontFamily);
-  static const SolarIconsData iPhone =
-      SolarIconsData(0xea41, fontFamily: _fontFamily);
-  static const SolarIconsData lightbulbBold =
-      SolarIconsData(0xea42, fontFamily: _fontFamily);
-  static const SolarIconsData lightbulbMinimalistic =
-      SolarIconsData(0xea43, fontFamily: _fontFamily);
-  static const SolarIconsData lightbulb =
-      SolarIconsData(0xea44, fontFamily: _fontFamily);
-  static const SolarIconsData lightning =
-      SolarIconsData(0xea46, fontFamily: _fontFamily);
-  static const SolarIconsData plugCircle =
-      SolarIconsData(0xea47, fontFamily: _fontFamily);
-  static const SolarIconsData sdCard =
-      SolarIconsData(0xea48, fontFamily: _fontFamily);
-  static const SolarIconsData smartphone2 =
-      SolarIconsData(0xea49, fontFamily: _fontFamily);
-  static const SolarIconsData smartphoneRotate2 =
-      SolarIconsData(0xea4a, fontFamily: _fontFamily);
-  static const SolarIconsData smartphoneRotateOrientation =
-      SolarIconsData(0xea4b, fontFamily: _fontFamily);
-  static const SolarIconsData smartphoneUpdate =
-      SolarIconsData(0xea4c, fontFamily: _fontFamily);
-  static const SolarIconsData smartphoneVibration =
-      SolarIconsData(0xea4d, fontFamily: _fontFamily);
-  static const SolarIconsData smartphone =
-      SolarIconsData(0xea4e, fontFamily: _fontFamily);
-  static const SolarIconsData socket =
-      SolarIconsData(0xea4f, fontFamily: _fontFamily);
-  static const SolarIconsData ssdRound =
-      SolarIconsData(0xea50, fontFamily: _fontFamily);
-  static const SolarIconsData ssdSquare =
-      SolarIconsData(0xea51, fontFamily: _fontFamily);
-  static const SolarIconsData weigher =
-      SolarIconsData(0xea52, fontFamily: _fontFamily);
-  static const SolarIconsData wirelessCharge =
-      SolarIconsData(0xea53, fontFamily: _fontFamily);
-  static const SolarIconsData bluetoothCircle =
-      SolarIconsData(0xea54, fontFamily: _fontFamily);
-  static const SolarIconsData bluetoothSquare =
-      SolarIconsData(0xea55, fontFamily: _fontFamily);
-  static const SolarIconsData bluetoothWave =
-      SolarIconsData(0xea56, fontFamily: _fontFamily);
-  static const SolarIconsData bluetooth =
-      SolarIconsData(0xea57, fontFamily: _fontFamily);
-  static const SolarIconsData cassette2 =
-      SolarIconsData(0xea58, fontFamily: _fontFamily);
-  static const SolarIconsData cassette =
-      SolarIconsData(0xea59, fontFamily: _fontFamily);
-  static const SolarIconsData display =
-      SolarIconsData(0xea5a, fontFamily: _fontFamily);
-  static const SolarIconsData gameboy =
-      SolarIconsData(0xea5b, fontFamily: _fontFamily);
-  static const SolarIconsData keyboard =
-      SolarIconsData(0xea5c, fontFamily: _fontFamily);
-  static const SolarIconsData monitorCamera =
-      SolarIconsData(0xea5d, fontFamily: _fontFamily);
-  static const SolarIconsData monitorSmartphone =
-      SolarIconsData(0xea5e, fontFamily: _fontFamily);
-  static const SolarIconsData monitor =
-      SolarIconsData(0xea5f, fontFamily: _fontFamily);
-  static const SolarIconsData printer2 =
-      SolarIconsData(0xea60, fontFamily: _fontFamily);
-  static const SolarIconsData printerMinimalistic =
-      SolarIconsData(0xea61, fontFamily: _fontFamily);
-  static const SolarIconsData printer =
-      SolarIconsData(0xea62, fontFamily: _fontFamily);
-  static const SolarIconsData projector =
-      SolarIconsData(0xea63, fontFamily: _fontFamily);
-  static const SolarIconsData radioMinimalistic =
-      SolarIconsData(0xea64, fontFamily: _fontFamily);
-  static const SolarIconsData radio =
-      SolarIconsData(0xea65, fontFamily: _fontFamily);
-  static const SolarIconsData simCardMinimalistic =
-      SolarIconsData(0xea66, fontFamily: _fontFamily);
-  static const SolarIconsData simCard =
-      SolarIconsData(0xea67, fontFamily: _fontFamily);
-  static const SolarIconsData simCards =
-      SolarIconsData(0xea68, fontFamily: _fontFamily);
-  static const SolarIconsData smartSpeaker2 =
-      SolarIconsData(0xea69, fontFamily: _fontFamily);
-  static const SolarIconsData smartSpeakerMinimalistic =
-      SolarIconsData(0xea6a, fontFamily: _fontFamily);
-  static const SolarIconsData smartSpeaker =
-      SolarIconsData(0xea6b, fontFamily: _fontFamily);
-  static const SolarIconsData telescope =
-      SolarIconsData(0xea6c, fontFamily: _fontFamily);
-  static const SolarIconsData tv =
-      SolarIconsData(0xea6d, fontFamily: _fontFamily);
-  static const SolarIconsData airbudsCaseCharge =
-      SolarIconsData(0xea6e, fontFamily: _fontFamily);
-  static const SolarIconsData airbudsCaseMinimalistic =
-      SolarIconsData(0xea6f, fontFamily: _fontFamily);
-  static const SolarIconsData airbudsCaseOpen =
-      SolarIconsData(0xea70, fontFamily: _fontFamily);
-  static const SolarIconsData airbudsCase =
-      SolarIconsData(0xea71, fontFamily: _fontFamily);
-  static const SolarIconsData airbudsCharge =
-      SolarIconsData(0xea72, fontFamily: _fontFamily);
-  static const SolarIconsData airbudsCheck =
-      SolarIconsData(0xea73, fontFamily: _fontFamily);
-  static const SolarIconsData airbudsLeft =
-      SolarIconsData(0xea74, fontFamily: _fontFamily);
-  static const SolarIconsData airbudsRemove =
-      SolarIconsData(0xea75, fontFamily: _fontFamily);
-  static const SolarIconsData airbudsRight =
-      SolarIconsData(0xea76, fontFamily: _fontFamily);
-  static const SolarIconsData airbuds =
-      SolarIconsData(0xea77, fontFamily: _fontFamily);
-  static const SolarIconsData boombox =
-      SolarIconsData(0xea78, fontFamily: _fontFamily);
-  static const SolarIconsData cpuBolt =
-      SolarIconsData(0xea79, fontFamily: _fontFamily);
-  static const SolarIconsData cpu =
-      SolarIconsData(0xea7a, fontFamily: _fontFamily);
-  static const SolarIconsData laptop2 =
-      SolarIconsData(0xea7b, fontFamily: _fontFamily);
-  static const SolarIconsData laptop3 =
-      SolarIconsData(0xea7c, fontFamily: _fontFamily);
-  static const SolarIconsData laptopMinimalistic =
-      SolarIconsData(0xea7d, fontFamily: _fontFamily);
-  static const SolarIconsData laptop =
-      SolarIconsData(0xea7e, fontFamily: _fontFamily);
-  static const SolarIconsData turntableMinimalistic =
-      SolarIconsData(0xea7f, fontFamily: _fontFamily);
-  static const SolarIconsData turntableMusicNote =
-      SolarIconsData(0xea80, fontFamily: _fontFamily);
-  static const SolarIconsData turntable =
-      SolarIconsData(0xea81, fontFamily: _fontFamily);
-  static const SolarIconsData moonFog =
-      SolarIconsData(0xea82, fontFamily: _fontFamily);
-  static const SolarIconsData snowflake =
-      SolarIconsData(0xea83, fontFamily: _fontFamily);
-  static const SolarIconsData sunfog =
-      SolarIconsData(0xea84, fontFamily: _fontFamily);
-  static const SolarIconsData sunrise =
-      SolarIconsData(0xea85, fontFamily: _fontFamily);
-  static const SolarIconsData sunset =
-      SolarIconsData(0xea86, fontFamily: _fontFamily);
-  static const SolarIconsData temperature =
-      SolarIconsData(0xea87, fontFamily: _fontFamily);
-  static const SolarIconsData tornadoSmall =
-      SolarIconsData(0xea88, fontFamily: _fontFamily);
-  static const SolarIconsData waterdrops =
-      SolarIconsData(0xea89, fontFamily: _fontFamily);
-  static const SolarIconsData wind =
-      SolarIconsData(0xea8a, fontFamily: _fontFamily);
-  static const SolarIconsData cloudBoltMinimalistic =
-      SolarIconsData(0xea8b, fontFamily: _fontFamily);
-  static const SolarIconsData cloudDownload =
-      SolarIconsData(0xea8c, fontFamily: _fontFamily);
-  static const SolarIconsData cloudRain =
-      SolarIconsData(0xea8d, fontFamily: _fontFamily);
-  static const SolarIconsData cloudSnowfallMinimalistic =
-      SolarIconsData(0xea8e, fontFamily: _fontFamily);
-  static const SolarIconsData cloudSnowfall =
-      SolarIconsData(0xea8f, fontFamily: _fontFamily);
-  static const SolarIconsData cloudStorm =
-      SolarIconsData(0xea90, fontFamily: _fontFamily);
-  static const SolarIconsData cloudSun2 =
-      SolarIconsData(0xea91, fontFamily: _fontFamily);
-  static const SolarIconsData cloudUpload =
-      SolarIconsData(0xea92, fontFamily: _fontFamily);
-  static const SolarIconsData cloudWaterdrop =
-      SolarIconsData(0xea93, fontFamily: _fontFamily);
-  static const SolarIconsData cloudWaterdrops =
-      SolarIconsData(0xea94, fontFamily: _fontFamily);
-  static const SolarIconsData cloudyMoon =
-      SolarIconsData(0xea95, fontFamily: _fontFamily);
-  static const SolarIconsData fog =
-      SolarIconsData(0xea96, fontFamily: _fontFamily);
-  static const SolarIconsData moonSleep =
-      SolarIconsData(0xea97, fontFamily: _fontFamily);
-  static const SolarIconsData moonStars =
-      SolarIconsData(0xea98, fontFamily: _fontFamily);
-  static const SolarIconsData moon =
-      SolarIconsData(0xea99, fontFamily: _fontFamily);
-  static const SolarIconsData stars =
-      SolarIconsData(0xea9a, fontFamily: _fontFamily);
-  static const SolarIconsData sun2 =
-      SolarIconsData(0xea9b, fontFamily: _fontFamily);
-  static const SolarIconsData sun =
-      SolarIconsData(0xea9c, fontFamily: _fontFamily);
-  static const SolarIconsData tornado =
-      SolarIconsData(0xea9d, fontFamily: _fontFamily);
-  static const SolarIconsData cloudBolt =
-      SolarIconsData(0xea9e, fontFamily: _fontFamily);
-  static const SolarIconsData cloudCheck =
-      SolarIconsData(0xea9f, fontFamily: _fontFamily);
-  static const SolarIconsData cloudMinus =
-      SolarIconsData(0xeaa0, fontFamily: _fontFamily);
-  static const SolarIconsData cloudPlus =
-      SolarIconsData(0xeaa1, fontFamily: _fontFamily);
-  static const SolarIconsData cloudSun =
-      SolarIconsData(0xeaa2, fontFamily: _fontFamily);
-  static const SolarIconsData cloud =
-      SolarIconsData(0xeaa3, fontFamily: _fontFamily);
-  static const SolarIconsData clouds =
-      SolarIconsData(0xeaa4, fontFamily: _fontFamily);
-  static const SolarIconsData cloudCross =
-      SolarIconsData(0xeaa5, fontFamily: _fontFamily);
-  static const SolarIconsData cloudFile =
-      SolarIconsData(0xeaa6, fontFamily: _fontFamily);
-  static const SolarIconsData codeFile =
-      SolarIconsData(0xeaa7, fontFamily: _fontFamily);
-  static const SolarIconsData figmaFile =
-      SolarIconsData(0xeaa8, fontFamily: _fontFamily);
-  static const SolarIconsData fileCheck =
-      SolarIconsData(0xeaa9, fontFamily: _fontFamily);
-  static const SolarIconsData fileCorrupted =
-      SolarIconsData(0xeaaa, fontFamily: _fontFamily);
-  static const SolarIconsData fileDownload =
-      SolarIconsData(0xeaab, fontFamily: _fontFamily);
-  static const SolarIconsData fileFavourite =
-      SolarIconsData(0xeaac, fontFamily: _fontFamily);
-  static const SolarIconsData fileLeft =
-      SolarIconsData(0xeaad, fontFamily: _fontFamily);
-  static const SolarIconsData fileRemove =
-      SolarIconsData(0xeaae, fontFamily: _fontFamily);
-  static const SolarIconsData fileRight =
-      SolarIconsData(0xeaaf, fontFamily: _fontFamily);
-  static const SolarIconsData fileSend =
-      SolarIconsData(0xeab0, fontFamily: _fontFamily);
-  static const SolarIconsData fileSmile =
-      SolarIconsData(0xeab1, fontFamily: _fontFamily);
-  static const SolarIconsData fileText =
-      SolarIconsData(0xeab2, fontFamily: _fontFamily);
-  static const SolarIconsData file =
-      SolarIconsData(0xeab3, fontFamily: _fontFamily);
-  static const SolarIconsData zipFile =
-      SolarIconsData(0xeab4, fontFamily: _fontFamily);
-  static const SolarIconsData addFolder =
-      SolarIconsData(0xeab5, fontFamily: _fontFamily);
-  static const SolarIconsData folder2 =
-      SolarIconsData(0xeab6, fontFamily: _fontFamily);
-  static const SolarIconsData folderCheck =
-      SolarIconsData(0xeab7, fontFamily: _fontFamily);
-  static const SolarIconsData folderCloud =
-      SolarIconsData(0xeab8, fontFamily: _fontFamily);
-  static const SolarIconsData folderError =
-      SolarIconsData(0xeab9, fontFamily: _fontFamily);
-  static const SolarIconsData folderFavouriteBookmark =
-      SolarIconsData(0xeaba, fontFamily: _fontFamily);
-  static const SolarIconsData folderFavouriteStar =
-      SolarIconsData(0xeabb, fontFamily: _fontFamily);
-  static const SolarIconsData folderOpen =
-      SolarIconsData(0xeabc, fontFamily: _fontFamily);
-  static const SolarIconsData folderPathConnect =
-      SolarIconsData(0xeabd, fontFamily: _fontFamily);
-  static const SolarIconsData folderSecurity =
-      SolarIconsData(0xeabe, fontFamily: _fontFamily);
-  static const SolarIconsData folderWithFiles =
-      SolarIconsData(0xeabf, fontFamily: _fontFamily);
-  static const SolarIconsData folder =
-      SolarIconsData(0xeac2, fontFamily: _fontFamily);
-  static const SolarIconsData moveToFolder =
-      SolarIconsData(0xeac3, fontFamily: _fontFamily);
-  static const SolarIconsData removeFolder =
-      SolarIconsData(0xeac4, fontFamily: _fontFamily);
-  static const SolarIconsData starFall2 =
-      SolarIconsData(0xeac5, fontFamily: _fontFamily);
-  static const SolarIconsData starRing =
-      SolarIconsData(0xeac6, fontFamily: _fontFamily);
-  static const SolarIconsData starRings =
-      SolarIconsData(0xeac7, fontFamily: _fontFamily);
-  static const SolarIconsData ufo2 =
-      SolarIconsData(0xeac8, fontFamily: _fontFamily);
-  static const SolarIconsData ufo3 =
-      SolarIconsData(0xeac9, fontFamily: _fontFamily);
-  static const SolarIconsData ufo =
-      SolarIconsData(0xeaca, fontFamily: _fontFamily);
-  static const SolarIconsData asteroid =
-      SolarIconsData(0xeacb, fontFamily: _fontFamily);
-  static const SolarIconsData atom =
-      SolarIconsData(0xeacc, fontFamily: _fontFamily);
-  static const SolarIconsData blackHole2 =
-      SolarIconsData(0xeacd, fontFamily: _fontFamily);
-  static const SolarIconsData blackHole3 =
-      SolarIconsData(0xeace, fontFamily: _fontFamily);
-  static const SolarIconsData earth =
-      SolarIconsData(0xeacf, fontFamily: _fontFamily);
-  static const SolarIconsData infinity =
-      SolarIconsData(0xead0, fontFamily: _fontFamily);
-  static const SolarIconsData men =
-      SolarIconsData(0xead1, fontFamily: _fontFamily);
-  static const SolarIconsData planet2 =
-      SolarIconsData(0xead2, fontFamily: _fontFamily);
-  static const SolarIconsData planet3 =
-      SolarIconsData(0xead3, fontFamily: _fontFamily);
-  static const SolarIconsData planet4 =
-      SolarIconsData(0xead4, fontFamily: _fontFamily);
-  static const SolarIconsData planet =
-      SolarIconsData(0xead5, fontFamily: _fontFamily);
-  static const SolarIconsData rocket2 =
-      SolarIconsData(0xead6, fontFamily: _fontFamily);
-  static const SolarIconsData rocket =
-      SolarIconsData(0xead7, fontFamily: _fontFamily);
-  static const SolarIconsData satellite =
-      SolarIconsData(0xead8, fontFamily: _fontFamily);
-  static const SolarIconsData starAngle =
-      SolarIconsData(0xead9, fontFamily: _fontFamily);
-  static const SolarIconsData starCircle =
-      SolarIconsData(0xeada, fontFamily: _fontFamily);
-  static const SolarIconsData starFallMinimalistic2 =
-      SolarIconsData(0xeadb, fontFamily: _fontFamily);
-  static const SolarIconsData starFallMinimalistic =
-      SolarIconsData(0xeadc, fontFamily: _fontFamily);
-  static const SolarIconsData starFall =
-      SolarIconsData(0xeadd, fontFamily: _fontFamily);
-  static const SolarIconsData starRainbow =
-      SolarIconsData(0xeade, fontFamily: _fontFamily);
-  static const SolarIconsData star =
-      SolarIconsData(0xeadf, fontFamily: _fontFamily);
-  static const SolarIconsData starsLine =
-      SolarIconsData(0xeae0, fontFamily: _fontFamily);
-  static const SolarIconsData starsMinimalistic =
-      SolarIconsData(0xeae1, fontFamily: _fontFamily);
-  static const SolarIconsData stars1 =
-      SolarIconsData(0xeae2, fontFamily: _fontFamily);
-  static const SolarIconsData women =
-      SolarIconsData(0xeae3, fontFamily: _fontFamily);
-  static const SolarIconsData blackHole =
-      SolarIconsData(0xeae4, fontFamily: _fontFamily);
-  static const SolarIconsData confoundedCircle =
-      SolarIconsData(0xeae5, fontFamily: _fontFamily);
-  static const SolarIconsData confoundedSquare =
-      SolarIconsData(0xeae6, fontFamily: _fontFamily);
-  static const SolarIconsData emojiFunnyCircle =
-      SolarIconsData(0xeae7, fontFamily: _fontFamily);
-  static const SolarIconsData emojiFunnySquare =
-      SolarIconsData(0xeae8, fontFamily: _fontFamily);
-  static const SolarIconsData facemaskCircle =
-      SolarIconsData(0xeae9, fontFamily: _fontFamily);
-  static const SolarIconsData facemaskSquare =
-      SolarIconsData(0xeaea, fontFamily: _fontFamily);
-  static const SolarIconsData sleepingCircle =
-      SolarIconsData(0xeaeb, fontFamily: _fontFamily);
-  static const SolarIconsData sleepingSquare =
-      SolarIconsData(0xeaec, fontFamily: _fontFamily);
-  static const SolarIconsData stickerCircle =
-      SolarIconsData(0xeaed, fontFamily: _fontFamily);
-  static const SolarIconsData stickerSmileCircle2 =
-      SolarIconsData(0xeaee, fontFamily: _fontFamily);
-  static const SolarIconsData stickerSmileCircle =
-      SolarIconsData(0xeaef, fontFamily: _fontFamily);
-  static const SolarIconsData stickerSmileSquare =
-      SolarIconsData(0xeaf0, fontFamily: _fontFamily);
-  static const SolarIconsData stickerSquare =
-      SolarIconsData(0xeaf1, fontFamily: _fontFamily);
-  static const SolarIconsData expressionlessCircle =
-      SolarIconsData(0xeaf2, fontFamily: _fontFamily);
-  static const SolarIconsData expressionlessSquare =
-      SolarIconsData(0xeaf3, fontFamily: _fontFamily);
-  static const SolarIconsData faceScanCircle =
-      SolarIconsData(0xeaf4, fontFamily: _fontFamily);
-  static const SolarIconsData faceScanSquare =
-      SolarIconsData(0xeaf5, fontFamily: _fontFamily);
-  static const SolarIconsData sadCircle =
-      SolarIconsData(0xeaf6, fontFamily: _fontFamily);
-  static const SolarIconsData sadSquare =
-      SolarIconsData(0xeaf7, fontFamily: _fontFamily);
-  static const SolarIconsData smileCircle =
-      SolarIconsData(0xeaf8, fontFamily: _fontFamily);
-  static const SolarIconsData smileSquare =
-      SolarIconsData(0xeaf9, fontFamily: _fontFamily);
-  static const SolarIconsData balls =
-      SolarIconsData(0xeafa, fontFamily: _fontFamily);
-  static const SolarIconsData basketball =
-      SolarIconsData(0xeafb, fontFamily: _fontFamily);
-  static const SolarIconsData bodyShapeMinimalistic =
-      SolarIconsData(0xeafc, fontFamily: _fontFamily);
-  static const SolarIconsData bodyShape =
-      SolarIconsData(0xeafd, fontFamily: _fontFamily);
-  static const SolarIconsData bowling =
-      SolarIconsData(0xeafe, fontFamily: _fontFamily);
-  static const SolarIconsData dumbbellLargeMinimalistic =
-      SolarIconsData(0xeaff, fontFamily: _fontFamily);
-  static const SolarIconsData dumbbellLarge =
-      SolarIconsData(0xeb00, fontFamily: _fontFamily);
-  static const SolarIconsData dumbbellSmall =
-      SolarIconsData(0xeb01, fontFamily: _fontFamily);
-  static const SolarIconsData dumbbell =
-      SolarIconsData(0xeb02, fontFamily: _fontFamily);
-  static const SolarIconsData dumbbells2 =
-      SolarIconsData(0xeb03, fontFamily: _fontFamily);
-  static const SolarIconsData dumbbells =
-      SolarIconsData(0xeb04, fontFamily: _fontFamily);
-  static const SolarIconsData football =
-      SolarIconsData(0xeb05, fontFamily: _fontFamily);
-  static const SolarIconsData golf =
-      SolarIconsData(0xeb06, fontFamily: _fontFamily);
-  static const SolarIconsData meditationRound =
-      SolarIconsData(0xeb07, fontFamily: _fontFamily);
-  static const SolarIconsData meditation =
-      SolarIconsData(0xeb08, fontFamily: _fontFamily);
-  static const SolarIconsData ranking =
-      SolarIconsData(0xeb09, fontFamily: _fontFamily);
-  static const SolarIconsData rugby =
-      SolarIconsData(0xeb0a, fontFamily: _fontFamily);
-  static const SolarIconsData stretchingRound =
-      SolarIconsData(0xeb0b, fontFamily: _fontFamily);
-  static const SolarIconsData stretching =
-      SolarIconsData(0xeb0c, fontFamily: _fontFamily);
-  static const SolarIconsData swimming =
-      SolarIconsData(0xeb0d, fontFamily: _fontFamily);
-  static const SolarIconsData tennis2 =
-      SolarIconsData(0xeb0e, fontFamily: _fontFamily);
-  static const SolarIconsData tennis =
-      SolarIconsData(0xeb0f, fontFamily: _fontFamily);
-  static const SolarIconsData treadmillRound =
-      SolarIconsData(0xeb10, fontFamily: _fontFamily);
-  static const SolarIconsData treadmill =
-      SolarIconsData(0xeb11, fontFamily: _fontFamily);
-  static const SolarIconsData volleyball2 =
-      SolarIconsData(0xeb12, fontFamily: _fontFamily);
-  static const SolarIconsData volleyball =
-      SolarIconsData(0xeb13, fontFamily: _fontFamily);
-  static const SolarIconsData waterSun =
-      SolarIconsData(0xeb14, fontFamily: _fontFamily);
-  static const SolarIconsData water =
-      SolarIconsData(0xeb15, fontFamily: _fontFamily);
-  static const SolarIconsData bicyclingRound =
-      SolarIconsData(0xeb16, fontFamily: _fontFamily);
-  static const SolarIconsData bicycling =
-      SolarIconsData(0xeb17, fontFamily: _fontFamily);
-  static const SolarIconsData hikingMinimalistic =
-      SolarIconsData(0xeb18, fontFamily: _fontFamily);
-  static const SolarIconsData hikingRound =
-      SolarIconsData(0xeb19, fontFamily: _fontFamily);
-  static const SolarIconsData hiking =
-      SolarIconsData(0xeb1a, fontFamily: _fontFamily);
-  static const SolarIconsData running_2 =
-      SolarIconsData(0xeb1b, fontFamily: _fontFamily);
-  static const SolarIconsData runningRound =
-      SolarIconsData(0xeb1c, fontFamily: _fontFamily);
-  static const SolarIconsData running =
-      SolarIconsData(0xeb1d, fontFamily: _fontFamily);
-  static const SolarIconsData skateboard =
-      SolarIconsData(0xeb1e, fontFamily: _fontFamily);
-  static const SolarIconsData skateboardingRound =
-      SolarIconsData(0xeb1f, fontFamily: _fontFamily);
-  static const SolarIconsData skateboarding =
-      SolarIconsData(0xeb20, fontFamily: _fontFamily);
-  static const SolarIconsData walkingRound =
-      SolarIconsData(0xeb21, fontFamily: _fontFamily);
-  static const SolarIconsData walking =
-      SolarIconsData(0xeb22, fontFamily: _fontFamily);
-  static const SolarIconsData magnifierBug =
-      SolarIconsData(0xeb23, fontFamily: _fontFamily);
-  static const SolarIconsData magnifierZoomIn =
-      SolarIconsData(0xeb24, fontFamily: _fontFamily);
-  static const SolarIconsData magnifierZoomOut =
-      SolarIconsData(0xeb25, fontFamily: _fontFamily);
-  static const SolarIconsData magnifier =
-      SolarIconsData(0xeb26, fontFamily: _fontFamily);
-  static const SolarIconsData minimalisticMagnifierBug =
-      SolarIconsData(0xeb27, fontFamily: _fontFamily);
-  static const SolarIconsData minimalisticMagnifierZoomIn =
-      SolarIconsData(0xeb28, fontFamily: _fontFamily);
-  static const SolarIconsData minimalisticMagnifierZoomOut =
-      SolarIconsData(0xeb2b, fontFamily: _fontFamily);
-  static const SolarIconsData minimalisticMagnifier =
-      SolarIconsData(0xeb2e, fontFamily: _fontFamily);
-  static const SolarIconsData roundedMagnifierBug =
-      SolarIconsData(0xeb2f, fontFamily: _fontFamily);
-  static const SolarIconsData roundedMagnifierZoomIn =
-      SolarIconsData(0xeb30, fontFamily: _fontFamily);
-  static const SolarIconsData roundedMagnifierZoomOut =
-      SolarIconsData(0xeb33, fontFamily: _fontFamily);
-  static const SolarIconsData roundedMagnifier =
-      SolarIconsData(0xeb36, fontFamily: _fontFamily);
-  static const SolarIconsData calendarAdd =
-      SolarIconsData(0xeb37, fontFamily: _fontFamily);
-  static const SolarIconsData calendarDate =
-      SolarIconsData(0xeb38, fontFamily: _fontFamily);
-  static const SolarIconsData calendarMark =
-      SolarIconsData(0xeb39, fontFamily: _fontFamily);
-  static const SolarIconsData calendarMinimalistic =
-      SolarIconsData(0xeb3a, fontFamily: _fontFamily);
-  static const SolarIconsData calendarSearch =
-      SolarIconsData(0xeb3b, fontFamily: _fontFamily);
-  static const SolarIconsData calendar =
-      SolarIconsData(0xeb3c, fontFamily: _fontFamily);
-  static const SolarIconsData history3 =
-      SolarIconsData(0xeb3d, fontFamily: _fontFamily);
-  static const SolarIconsData hourglassLine =
-      SolarIconsData(0xeb3e, fontFamily: _fontFamily);
-  static const SolarIconsData hourglass =
-      SolarIconsData(0xeb3f, fontFamily: _fontFamily);
-  static const SolarIconsData watchRound =
-      SolarIconsData(0xeb40, fontFamily: _fontFamily);
-  static const SolarIconsData watchSquareMinimalisticCharge =
-      SolarIconsData(0xeb41, fontFamily: _fontFamily);
-  static const SolarIconsData watchSquareMinimalistic =
-      SolarIconsData(0xeb42, fontFamily: _fontFamily);
-  static const SolarIconsData watchSquare =
-      SolarIconsData(0xeb43, fontFamily: _fontFamily);
-  static const SolarIconsData alarmAdd =
-      SolarIconsData(0xeb47, fontFamily: _fontFamily);
-  static const SolarIconsData alarmPause =
-      SolarIconsData(0xeb48, fontFamily: _fontFamily);
-  static const SolarIconsData alarmPlay =
-      SolarIconsData(0xeb49, fontFamily: _fontFamily);
-  static const SolarIconsData alarmRemove =
-      SolarIconsData(0xeb4a, fontFamily: _fontFamily);
-  static const SolarIconsData alarmSleep =
-      SolarIconsData(0xeb4b, fontFamily: _fontFamily);
-  static const SolarIconsData alarmTurnOff =
-      SolarIconsData(0xeb4c, fontFamily: _fontFamily);
-  static const SolarIconsData alarm =
-      SolarIconsData(0xeb4d, fontFamily: _fontFamily);
-  static const SolarIconsData clockCircle =
-      SolarIconsData(0xeb4e, fontFamily: _fontFamily);
-  static const SolarIconsData clockSquare =
-      SolarIconsData(0xeb50, fontFamily: _fontFamily);
-  static const SolarIconsData history_2 =
-      SolarIconsData(0xeb52, fontFamily: _fontFamily);
-  static const SolarIconsData history =
-      SolarIconsData(0xeb53, fontFamily: _fontFamily);
-  static const SolarIconsData stopwatchPause =
-      SolarIconsData(0xeb54, fontFamily: _fontFamily);
-  static const SolarIconsData stopwatchPlay =
-      SolarIconsData(0xeb55, fontFamily: _fontFamily);
-  static const SolarIconsData stopwatch =
-      SolarIconsData(0xeb56, fontFamily: _fontFamily);
-  static const SolarIconsData bill1 =
-      SolarIconsData(0xeb57, fontFamily: _fontFamily);
-  static const SolarIconsData checklistMinimalistic =
-      SolarIconsData(0xeb58, fontFamily: _fontFamily);
-  static const SolarIconsData checklist =
-      SolarIconsData(0xeb59, fontFamily: _fontFamily);
-  static const SolarIconsData listArrowDownMinimalistic =
-      SolarIconsData(0xeb5a, fontFamily: _fontFamily);
-  static const SolarIconsData listArrowDown =
-      SolarIconsData(0xeb5b, fontFamily: _fontFamily);
-  static const SolarIconsData listArrowUpMinimalistic =
-      SolarIconsData(0xeb5c, fontFamily: _fontFamily);
-  static const SolarIconsData listArrowUp =
-      SolarIconsData(0xeb5d, fontFamily: _fontFamily);
-  static const SolarIconsData listUpMinimalistic =
-      SolarIconsData(0xeb5e, fontFamily: _fontFamily);
-  static const SolarIconsData listUp =
-      SolarIconsData(0xeb5f, fontFamily: _fontFamily);
-  static const SolarIconsData list_1 =
-      SolarIconsData(0xeb60, fontFamily: _fontFamily);
-  static const SolarIconsData playlist =
-      SolarIconsData(0xeb61, fontFamily: _fontFamily);
-  static const SolarIconsData sortByAlphabet =
-      SolarIconsData(0xeb62, fontFamily: _fontFamily);
-  static const SolarIconsData sortByTime =
-      SolarIconsData(0xeb63, fontFamily: _fontFamily);
-  static const SolarIconsData listCheckMinimalistic =
-      SolarIconsData(0xeb64, fontFamily: _fontFamily);
-  static const SolarIconsData listCheck =
-      SolarIconsData(0xeb65, fontFamily: _fontFamily);
-  static const SolarIconsData listCrossMinimalistic =
-      SolarIconsData(0xeb66, fontFamily: _fontFamily);
-  static const SolarIconsData listCross =
-      SolarIconsData(0xeb67, fontFamily: _fontFamily);
-  static const SolarIconsData listDownMinimalistic =
-      SolarIconsData(0xeb68, fontFamily: _fontFamily);
-  static const SolarIconsData listDown =
-      SolarIconsData(0xeb69, fontFamily: _fontFamily);
-  static const SolarIconsData listHeartMinimalistic =
-      SolarIconsData(0xeb6a, fontFamily: _fontFamily);
-  static const SolarIconsData listHeart =
-      SolarIconsData(0xeb6b, fontFamily: _fontFamily);
-  static const SolarIconsData list =
-      SolarIconsData(0xeb6c, fontFamily: _fontFamily);
-  static const SolarIconsData playlistMinimalistic =
-      SolarIconsData(0xeb6d, fontFamily: _fontFamily);
-  static const SolarIconsData playlist_2 =
-      SolarIconsData(0xeb6e, fontFamily: _fontFamily);
-  static const SolarIconsData playlistMinimalistic2 =
-      SolarIconsData(0xeb6f, fontFamily: _fontFamily);
-  static const SolarIconsData playlistMinimalistic3 =
-      SolarIconsData(0xeb70, fontFamily: _fontFamily);
-  static const SolarIconsData sortFromBottomToTop =
-      SolarIconsData(0xeb71, fontFamily: _fontFamily);
-  static const SolarIconsData sortFromTopToBottom =
-      SolarIconsData(0xeb72, fontFamily: _fontFamily);
-  static const SolarIconsData callChat =
-      SolarIconsData(0xeb73, fontFamily: _fontFamily);
-  static const SolarIconsData callDropped =
-      SolarIconsData(0xeb74, fontFamily: _fontFamily);
-  static const SolarIconsData callMedicine =
-      SolarIconsData(0xeb75, fontFamily: _fontFamily);
-  static const SolarIconsData incomingCall =
-      SolarIconsData(0xeb76, fontFamily: _fontFamily);
-  static const SolarIconsData outgoingCall =
-      SolarIconsData(0xeb77, fontFamily: _fontFamily);
-  static const SolarIconsData recordCircle1 =
-      SolarIconsData(0xeb78, fontFamily: _fontFamily);
-  static const SolarIconsData recordMinimalistic =
-      SolarIconsData(0xeb79, fontFamily: _fontFamily);
-  static const SolarIconsData recordSquare =
-      SolarIconsData(0xeb7a, fontFamily: _fontFamily);
-  static const SolarIconsData callCancelRounded =
-      SolarIconsData(0xeb7b, fontFamily: _fontFamily);
-  static const SolarIconsData callCancel =
-      SolarIconsData(0xeb7c, fontFamily: _fontFamily);
-  static const SolarIconsData callChatRounded =
-      SolarIconsData(0xeb7d, fontFamily: _fontFamily);
-  static const SolarIconsData callDroppedRounded =
-      SolarIconsData(0xeb7e, fontFamily: _fontFamily);
-  static const SolarIconsData callMedicineRounded =
-      SolarIconsData(0xeb7f, fontFamily: _fontFamily);
-  static const SolarIconsData endCallRounded =
-      SolarIconsData(0xeb80, fontFamily: _fontFamily);
-  static const SolarIconsData endCall =
-      SolarIconsData(0xeb81, fontFamily: _fontFamily);
-  static const SolarIconsData incomingCallRounded =
-      SolarIconsData(0xeb82, fontFamily: _fontFamily);
-  static const SolarIconsData outgoingCallRounded =
-      SolarIconsData(0xeb83, fontFamily: _fontFamily);
-  static const SolarIconsData phoneCallingRounded =
-      SolarIconsData(0xeb84, fontFamily: _fontFamily);
-  static const SolarIconsData phoneCalling =
-      SolarIconsData(0xeb85, fontFamily: _fontFamily);
-  static const SolarIconsData phoneRounded =
-      SolarIconsData(0xeb86, fontFamily: _fontFamily);
-  static const SolarIconsData phone =
-      SolarIconsData(0xeb87, fontFamily: _fontFamily);
-  static const SolarIconsData boneBroken =
-      SolarIconsData(0xeb88, fontFamily: _fontFamily);
-  static const SolarIconsData boneCrack =
-      SolarIconsData(0xeb89, fontFamily: _fontFamily);
-  static const SolarIconsData bone =
-      SolarIconsData(0xeb8a, fontFamily: _fontFamily);
-  static const SolarIconsData bones =
-      SolarIconsData(0xeb8b, fontFamily: _fontFamily);
-  static const SolarIconsData health =
-      SolarIconsData(0xeb8c, fontFamily: _fontFamily);
-  static const SolarIconsData heartPulse2 =
-      SolarIconsData(0xeb8d, fontFamily: _fontFamily);
-  static const SolarIconsData heartPulse =
-      SolarIconsData(0xeb8e, fontFamily: _fontFamily);
-  static const SolarIconsData medicalKit =
-      SolarIconsData(0xeb8f, fontFamily: _fontFamily);
-  static const SolarIconsData pills =
-      SolarIconsData(0xeb90, fontFamily: _fontFamily);
-  static const SolarIconsData pulse_2 =
-      SolarIconsData(0xeb91, fontFamily: _fontFamily);
-  static const SolarIconsData pulse =
-      SolarIconsData(0xeb92, fontFamily: _fontFamily);
-  static const SolarIconsData testTubeMinimalistic =
-      SolarIconsData(0xeb93, fontFamily: _fontFamily);
-  static const SolarIconsData testTube =
-      SolarIconsData(0xeb94, fontFamily: _fontFamily);
-  static const SolarIconsData virus =
-      SolarIconsData(0xeb95, fontFamily: _fontFamily);
-  static const SolarIconsData adhesivePlaster2 =
-      SolarIconsData(0xeb96, fontFamily: _fontFamily);
-  static const SolarIconsData adhesivePlaster =
-      SolarIconsData(0xeb97, fontFamily: _fontFamily);
-  static const SolarIconsData bacteria =
-      SolarIconsData(0xeb98, fontFamily: _fontFamily);
-  static const SolarIconsData benzeneRing =
-      SolarIconsData(0xeb99, fontFamily: _fontFamily);
-  static const SolarIconsData dna =
-      SolarIconsData(0xeb9a, fontFamily: _fontFamily);
-  static const SolarIconsData dropper_2 =
-      SolarIconsData(0xeb9b, fontFamily: _fontFamily);
-  static const SolarIconsData dropper_3 =
-      SolarIconsData(0xeb9c, fontFamily: _fontFamily);
-  static const SolarIconsData dropperMinimalistic2 =
-      SolarIconsData(0xeb9d, fontFamily: _fontFamily);
-  static const SolarIconsData dropperMinimalistic =
-      SolarIconsData(0xeb9e, fontFamily: _fontFamily);
-  static const SolarIconsData dropper =
-      SolarIconsData(0xeb9f, fontFamily: _fontFamily);
-  static const SolarIconsData jarOfPills2 =
-      SolarIconsData(0xeba0, fontFamily: _fontFamily);
-  static const SolarIconsData jarOfPills =
-      SolarIconsData(0xeba1, fontFamily: _fontFamily);
-  static const SolarIconsData pill =
-      SolarIconsData(0xeba2, fontFamily: _fontFamily);
-  static const SolarIconsData pills_2 =
-      SolarIconsData(0xeba3, fontFamily: _fontFamily);
-  static const SolarIconsData pills_3 =
-      SolarIconsData(0xeba4, fontFamily: _fontFamily);
-  static const SolarIconsData stethoscope =
-      SolarIconsData(0xeba5, fontFamily: _fontFamily);
-  static const SolarIconsData syringe =
-      SolarIconsData(0xeba6, fontFamily: _fontFamily);
-  static const SolarIconsData thermometer =
-      SolarIconsData(0xeba7, fontFamily: _fontFamily);
-  static const SolarIconsData armchair_2 =
-      SolarIconsData(0xeba8, fontFamily: _fontFamily);
-  static const SolarIconsData armchair =
-      SolarIconsData(0xeba9, fontFamily: _fontFamily);
-  static const SolarIconsData barChair =
-      SolarIconsData(0xebaa, fontFamily: _fontFamily);
-  static const SolarIconsData bath =
-      SolarIconsData(0xebab, fontFamily: _fontFamily);
-  static const SolarIconsData bed =
-      SolarIconsData(0xebac, fontFamily: _fontFamily);
-  static const SolarIconsData bedsideTable2 =
-      SolarIconsData(0xebad, fontFamily: _fontFamily);
-  static const SolarIconsData bedsideTable3 =
-      SolarIconsData(0xebae, fontFamily: _fontFamily);
-  static const SolarIconsData bedsideTable4 =
-      SolarIconsData(0xebaf, fontFamily: _fontFamily);
-  static const SolarIconsData bedsideTable =
-      SolarIconsData(0xebb0, fontFamily: _fontFamily);
-  static const SolarIconsData chair_2 =
-      SolarIconsData(0xebb1, fontFamily: _fontFamily);
-  static const SolarIconsData chair =
-      SolarIconsData(0xebb2, fontFamily: _fontFamily);
-  static const SolarIconsData chandelier =
-      SolarIconsData(0xebb3, fontFamily: _fontFamily);
-  static const SolarIconsData closet_2 =
-      SolarIconsData(0xebb4, fontFamily: _fontFamily);
-  static const SolarIconsData closet =
-      SolarIconsData(0xebb5, fontFamily: _fontFamily);
-  static const SolarIconsData floorLampMinimalistic =
-      SolarIconsData(0xebb6, fontFamily: _fontFamily);
-  static const SolarIconsData floorLamp =
-      SolarIconsData(0xebb7, fontFamily: _fontFamily);
-  static const SolarIconsData fridge =
-      SolarIconsData(0xebb8, fontFamily: _fontFamily);
-  static const SolarIconsData lamp =
-      SolarIconsData(0xebb9, fontFamily: _fontFamily);
-  static const SolarIconsData mirror =
-      SolarIconsData(0xebba, fontFamily: _fontFamily);
-  static const SolarIconsData smartVacuumCleaner_2 =
-      SolarIconsData(0xebbb, fontFamily: _fontFamily);
-  static const SolarIconsData smartVacuumCleaner =
-      SolarIconsData(0xebbc, fontFamily: _fontFamily);
-  static const SolarIconsData sofa_2 =
-      SolarIconsData(0xebbd, fontFamily: _fontFamily);
-  static const SolarIconsData sofa_3 =
-      SolarIconsData(0xebbe, fontFamily: _fontFamily);
-  static const SolarIconsData trellis =
-      SolarIconsData(0xebbf, fontFamily: _fontFamily);
-  static const SolarIconsData volumeKnob =
-      SolarIconsData(0xebc0, fontFamily: _fontFamily);
-  static const SolarIconsData conditioner_2 =
-      SolarIconsData(0xebc1, fontFamily: _fontFamily);
-  static const SolarIconsData conditioner =
-      SolarIconsData(0xebc2, fontFamily: _fontFamily);
-  static const SolarIconsData remoteController2 =
-      SolarIconsData(0xebc3, fontFamily: _fontFamily);
-  static const SolarIconsData remoteControllerMinimalistic =
-      SolarIconsData(0xebc4, fontFamily: _fontFamily);
-  static const SolarIconsData remoteController =
-      SolarIconsData(0xebc5, fontFamily: _fontFamily);
-  static const SolarIconsData sofa =
-      SolarIconsData(0xebc6, fontFamily: _fontFamily);
-  static const SolarIconsData speakerMinimalistic =
-      SolarIconsData(0xebc7, fontFamily: _fontFamily);
-  static const SolarIconsData speaker =
-      SolarIconsData(0xebc8, fontFamily: _fontFamily);
-  static const SolarIconsData washingMachineMinimalistic =
-      SolarIconsData(0xebc9, fontFamily: _fontFamily);
-  static const SolarIconsData washingMachine =
-      SolarIconsData(0xebca, fontFamily: _fontFamily);
-  static const SolarIconsData settingsMinimalistic =
-      SolarIconsData(0xebcb, fontFamily: _fontFamily);
-  static const SolarIconsData settings =
-      SolarIconsData(0xebcc, fontFamily: _fontFamily);
-  static const SolarIconsData tuning_2 =
-      SolarIconsData(0xebcd, fontFamily: _fontFamily);
-  static const SolarIconsData tuning_3 =
-      SolarIconsData(0xebce, fontFamily: _fontFamily);
-  static const SolarIconsData tuning_4 =
-      SolarIconsData(0xebcf, fontFamily: _fontFamily);
-  static const SolarIconsData tuningSquare_2 =
-      SolarIconsData(0xebd0, fontFamily: _fontFamily);
-  static const SolarIconsData tuningSquare =
-      SolarIconsData(0xebd1, fontFamily: _fontFamily);
-  static const SolarIconsData tuning =
-      SolarIconsData(0xebd2, fontFamily: _fontFamily);
-  static const SolarIconsData widget_2 =
-      SolarIconsData(0xebd3, fontFamily: _fontFamily);
-  static const SolarIconsData widget_3 =
-      SolarIconsData(0xebd4, fontFamily: _fontFamily);
-  static const SolarIconsData widget_4 =
-      SolarIconsData(0xebd5, fontFamily: _fontFamily);
-  static const SolarIconsData widget_5 =
-      SolarIconsData(0xebd6, fontFamily: _fontFamily);
-  static const SolarIconsData widget_6 =
-      SolarIconsData(0xebd7, fontFamily: _fontFamily);
-  static const SolarIconsData widgetAdd =
-      SolarIconsData(0xebd8, fontFamily: _fontFamily);
-  static const SolarIconsData widget =
-      SolarIconsData(0xebd9, fontFamily: _fontFamily);
-  static const SolarIconsData hashtagChat =
-      SolarIconsData(0xebda, fontFamily: _fontFamily);
-  static const SolarIconsData hashtagCircle =
-      SolarIconsData(0xebdb, fontFamily: _fontFamily);
-  static const SolarIconsData bugMinimalistic =
-      SolarIconsData(0xebdc, fontFamily: _fontFamily);
-  static const SolarIconsData bug =
-      SolarIconsData(0xebdd, fontFamily: _fontFamily);
-  static const SolarIconsData code2 =
-      SolarIconsData(0xebde, fontFamily: _fontFamily);
-  static const SolarIconsData codeCircle =
-      SolarIconsData(0xebdf, fontFamily: _fontFamily);
-  static const SolarIconsData codeSquare =
-      SolarIconsData(0xebe0, fontFamily: _fontFamily);
-  static const SolarIconsData code =
-      SolarIconsData(0xebe1, fontFamily: _fontFamily);
-  static const SolarIconsData command =
-      SolarIconsData(0xebe2, fontFamily: _fontFamily);
-  static const SolarIconsData hashtagSquare =
-      SolarIconsData(0xebe3, fontFamily: _fontFamily);
-  static const SolarIconsData hashtag =
-      SolarIconsData(0xebe4, fontFamily: _fontFamily);
-  static const SolarIconsData programming =
-      SolarIconsData(0xebe5, fontFamily: _fontFamily);
-  static const SolarIconsData screencast_2 =
-      SolarIconsData(0xebe6, fontFamily: _fontFamily);
-  static const SolarIconsData screencast =
-      SolarIconsData(0xebe7, fontFamily: _fontFamily);
-  static const SolarIconsData sidebarCode =
-      SolarIconsData(0xebe8, fontFamily: _fontFamily);
-  static const SolarIconsData sidebarMinimalistic =
-      SolarIconsData(0xebe9, fontFamily: _fontFamily);
-  static const SolarIconsData sidebar =
-      SolarIconsData(0xebea, fontFamily: _fontFamily);
-  static const SolarIconsData slashCircle =
-      SolarIconsData(0xebeb, fontFamily: _fontFamily);
-  static const SolarIconsData slashSquare =
-      SolarIconsData(0xebec, fontFamily: _fontFamily);
-  static const SolarIconsData stationMinimalistic =
-      SolarIconsData(0xebed, fontFamily: _fontFamily);
-  static const SolarIconsData station =
-      SolarIconsData(0xebee, fontFamily: _fontFamily);
-  static const SolarIconsData structure =
-      SolarIconsData(0xebef, fontFamily: _fontFamily);
-  static const SolarIconsData translation_2 =
-      SolarIconsData(0xebf0, fontFamily: _fontFamily);
-  static const SolarIconsData translation =
-      SolarIconsData(0xebf1, fontFamily: _fontFamily);
-  static const SolarIconsData usbCircle =
-      SolarIconsData(0xebf2, fontFamily: _fontFamily);
-  static const SolarIconsData usbSquare =
-      SolarIconsData(0xebf3, fontFamily: _fontFamily);
-  static const SolarIconsData usb =
-      SolarIconsData(0xebf4, fontFamily: _fontFamily);
-  static const SolarIconsData windowFrame =
-      SolarIconsData(0xebf5, fontFamily: _fontFamily);
-  static const SolarIconsData wifiRouterMinimalistic =
-      SolarIconsData(0xebf6, fontFamily: _fontFamily);
-  static const SolarIconsData wifiRouterRound =
-      SolarIconsData(0xebf7, fontFamily: _fontFamily);
-  static const SolarIconsData wifiRouter =
-      SolarIconsData(0xebf8, fontFamily: _fontFamily);
-  static const SolarIconsData backspace =
-      SolarIconsData(0xebf9, fontFamily: _fontFamily);
-  static const SolarIconsData linkBrokenMinimalistic =
-      SolarIconsData(0xebfa, fontFamily: _fontFamily);
-  static const SolarIconsData linkBroken =
-      SolarIconsData(0xebfb, fontFamily: _fontFamily);
-  static const SolarIconsData linkCircle =
-      SolarIconsData(0xebfc, fontFamily: _fontFamily);
-  static const SolarIconsData linkMinimalistic_2 =
-      SolarIconsData(0xebfd, fontFamily: _fontFamily);
-  static const SolarIconsData linkMinimalistic =
-      SolarIconsData(0xebfe, fontFamily: _fontFamily);
-  static const SolarIconsData linkRoundAngle =
-      SolarIconsData(0xebff, fontFamily: _fontFamily);
-  static const SolarIconsData linkRound =
-      SolarIconsData(0xec00, fontFamily: _fontFamily);
-  static const SolarIconsData linkSquare =
-      SolarIconsData(0xec01, fontFamily: _fontFamily);
-  static const SolarIconsData link =
-      SolarIconsData(0xec02, fontFamily: _fontFamily);
-  static const SolarIconsData paragraphSpacing =
-      SolarIconsData(0xec03, fontFamily: _fontFamily);
-  static const SolarIconsData textBoldCircle =
-      SolarIconsData(0xec04, fontFamily: _fontFamily);
-  static const SolarIconsData textBoldSquare =
-      SolarIconsData(0xec05, fontFamily: _fontFamily);
-  static const SolarIconsData textBold =
-      SolarIconsData(0xec06, fontFamily: _fontFamily);
-  static const SolarIconsData textCrossCircle =
-      SolarIconsData(0xec07, fontFamily: _fontFamily);
-  static const SolarIconsData textCrossSquare =
-      SolarIconsData(0xec08, fontFamily: _fontFamily);
-  static const SolarIconsData textCross =
-      SolarIconsData(0xec09, fontFamily: _fontFamily);
-  static const SolarIconsData textFieldFocus =
-      SolarIconsData(0xec0a, fontFamily: _fontFamily);
-  static const SolarIconsData textField =
-      SolarIconsData(0xec0b, fontFamily: _fontFamily);
-  static const SolarIconsData textSelection =
-      SolarIconsData(0xec0c, fontFamily: _fontFamily);
-  static const SolarIconsData textSquare2 =
-      SolarIconsData(0xec0d, fontFamily: _fontFamily);
-  static const SolarIconsData textSquare =
-      SolarIconsData(0xec0e, fontFamily: _fontFamily);
-  static const SolarIconsData textUnderlineCircle =
-      SolarIconsData(0xec0f, fontFamily: _fontFamily);
-  static const SolarIconsData textUnderlineCross =
-      SolarIconsData(0xec10, fontFamily: _fontFamily);
-  static const SolarIconsData textUnderline =
-      SolarIconsData(0xec11, fontFamily: _fontFamily);
-  static const SolarIconsData text =
-      SolarIconsData(0xec12, fontFamily: _fontFamily);
-  static const SolarIconsData eraserCircle =
-      SolarIconsData(0xec13, fontFamily: _fontFamily);
-  static const SolarIconsData eraserSquare =
-      SolarIconsData(0xec14, fontFamily: _fontFamily);
-  static const SolarIconsData eraser =
-      SolarIconsData(0xec15, fontFamily: _fontFamily);
-  static const SolarIconsData textCircle =
-      SolarIconsData(0xec16, fontFamily: _fontFamily);
-  static const SolarIconsData textItalicCircle =
-      SolarIconsData(0xec17, fontFamily: _fontFamily);
-  static const SolarIconsData textItalicSquare =
-      SolarIconsData(0xec18, fontFamily: _fontFamily);
-  static const SolarIconsData textItalic =
-      SolarIconsData(0xec19, fontFamily: _fontFamily);
-  static const SolarIconsData chart_2 =
-      SolarIconsData(0xec1a, fontFamily: _fontFamily);
-  static const SolarIconsData chartSquare =
-      SolarIconsData(0xec1b, fontFamily: _fontFamily);
-  static const SolarIconsData chart =
-      SolarIconsData(0xec1c, fontFamily: _fontFamily);
-  static const SolarIconsData chatSquare_2 =
-      SolarIconsData(0xec1d, fontFamily: _fontFamily);
-  static const SolarIconsData courseDown =
-      SolarIconsData(0xec1e, fontFamily: _fontFamily);
-  static const SolarIconsData courseUp =
-      SolarIconsData(0xec1f, fontFamily: _fontFamily);
-  static const SolarIconsData diagramDown =
-      SolarIconsData(0xec20, fontFamily: _fontFamily);
-  static const SolarIconsData diagramUp =
-      SolarIconsData(0xec21, fontFamily: _fontFamily);
-  static const SolarIconsData graphDownNew =
-      SolarIconsData(0xec22, fontFamily: _fontFamily);
-  static const SolarIconsData graphDown =
-      SolarIconsData(0xec23, fontFamily: _fontFamily);
-  static const SolarIconsData graphNewUp =
-      SolarIconsData(0xec24, fontFamily: _fontFamily);
-  static const SolarIconsData graphNew =
-      SolarIconsData(0xec25, fontFamily: _fontFamily);
-  static const SolarIconsData graphUp =
-      SolarIconsData(0xec26, fontFamily: _fontFamily);
-  static const SolarIconsData graph =
-      SolarIconsData(0xec27, fontFamily: _fontFamily);
-  static const SolarIconsData pieChart3 =
-      SolarIconsData(0xec28, fontFamily: _fontFamily);
-  static const SolarIconsData presentationGraph =
-      SolarIconsData(0xec29, fontFamily: _fontFamily);
-  static const SolarIconsData roundGraph =
-      SolarIconsData(0xec2a, fontFamily: _fontFamily);
-  static const SolarIconsData pieChart2 =
-      SolarIconsData(0xec2b, fontFamily: _fontFamily);
-  static const SolarIconsData pieChart =
-      SolarIconsData(0xec2c, fontFamily: _fontFamily);
-  static const SolarIconsData bag2 =
-      SolarIconsData(0xec2d, fontFamily: _fontFamily);
-  static const SolarIconsData bag3 =
-      SolarIconsData(0xec2e, fontFamily: _fontFamily);
-  static const SolarIconsData bag4 =
-      SolarIconsData(0xec2f, fontFamily: _fontFamily);
-  static const SolarIconsData bag5 =
-      SolarIconsData(0xec30, fontFamily: _fontFamily);
-  static const SolarIconsData bagCheck =
-      SolarIconsData(0xec31, fontFamily: _fontFamily);
-  static const SolarIconsData bagCross =
-      SolarIconsData(0xec32, fontFamily: _fontFamily);
-  static const SolarIconsData bagHeart =
-      SolarIconsData(0xec33, fontFamily: _fontFamily);
-  static const SolarIconsData bagMusic_2 =
-      SolarIconsData(0xec34, fontFamily: _fontFamily);
-  static const SolarIconsData bagMusic =
-      SolarIconsData(0xec35, fontFamily: _fontFamily);
-  static const SolarIconsData bagSmile =
-      SolarIconsData(0xec36, fontFamily: _fontFamily);
-  static const SolarIconsData bag =
-      SolarIconsData(0xec37, fontFamily: _fontFamily);
-  static const SolarIconsData cart_2 =
-      SolarIconsData(0xec38, fontFamily: _fontFamily);
-  static const SolarIconsData cart_3 =
-      SolarIconsData(0xec39, fontFamily: _fontFamily);
-  static const SolarIconsData cart_4 =
-      SolarIconsData(0xec3a, fontFamily: _fontFamily);
-  static const SolarIconsData cart_5 =
-      SolarIconsData(0xec3b, fontFamily: _fontFamily);
-  static const SolarIconsData cart =
-      SolarIconsData(0xec3c, fontFamily: _fontFamily);
-  static const SolarIconsData shop_2 =
-      SolarIconsData(0xec3d, fontFamily: _fontFamily);
-  static const SolarIconsData shopMinimalistic =
-      SolarIconsData(0xec3e, fontFamily: _fontFamily);
-  static const SolarIconsData shop =
-      SolarIconsData(0xec3f, fontFamily: _fontFamily);
-  static const SolarIconsData cartCheck =
-      SolarIconsData(0xec40, fontFamily: _fontFamily);
-  static const SolarIconsData cartCross =
-      SolarIconsData(0xec41, fontFamily: _fontFamily);
-  static const SolarIconsData cartLarge2 =
-      SolarIconsData(0xec42, fontFamily: _fontFamily);
-  static const SolarIconsData cartLarge3 =
-      SolarIconsData(0xec43, fontFamily: _fontFamily);
-  static const SolarIconsData cartLarge_4 =
-      SolarIconsData(0xec44, fontFamily: _fontFamily);
-  static const SolarIconsData cartLargeMinimalistic =
-      SolarIconsData(0xec45, fontFamily: _fontFamily);
-  static const SolarIconsData cartLarge =
-      SolarIconsData(0xec46, fontFamily: _fontFamily);
-  static const SolarIconsData cartPlus =
-      SolarIconsData(0xec47, fontFamily: _fontFamily);
-  static const SolarIconsData suitcaseLines =
-      SolarIconsData(0xec48, fontFamily: _fontFamily);
-  static const SolarIconsData suitcaseTag =
-      SolarIconsData(0xec49, fontFamily: _fontFamily);
-  static const SolarIconsData bonfire =
-      SolarIconsData(0xec4a, fontFamily: _fontFamily);
-  static const SolarIconsData fireMinimalistic =
-      SolarIconsData(0xec4b, fontFamily: _fontFamily);
-  static const SolarIconsData fireSquare =
-      SolarIconsData(0xec4c, fontFamily: _fontFamily);
-  static const SolarIconsData fire =
-      SolarIconsData(0xec4d, fontFamily: _fontFamily);
-  static const SolarIconsData flame =
-      SolarIconsData(0xec4e, fontFamily: _fontFamily);
-  static const SolarIconsData leaf =
-      SolarIconsData(0xec4f, fontFamily: _fontFamily);
-  static const SolarIconsData suitcase =
-      SolarIconsData(0xec50, fontFamily: _fontFamily);
-  static const SolarIconsData backpack =
-      SolarIconsData(0xec51, fontFamily: _fontFamily);
-  static const SolarIconsData caseRound =
-      SolarIconsData(0xec52, fontFamily: _fontFamily);
-  static const SolarIconsData case_ =
-      SolarIconsData(0xec53, fontFamily: _fontFamily);
-  static const SolarIconsData squareAcademicCap2 =
-      SolarIconsData(0xec54, fontFamily: _fontFamily);
-  static const SolarIconsData squareAcademicCap =
-      SolarIconsData(0xec55, fontFamily: _fontFamily);
-  static const SolarIconsData book2 =
-      SolarIconsData(0xec56, fontFamily: _fontFamily);
-  static const SolarIconsData bookBookmarkMinimalistic =
-      SolarIconsData(0xec57, fontFamily: _fontFamily);
-  static const SolarIconsData bookBookmark =
-      SolarIconsData(0xec58, fontFamily: _fontFamily);
-  static const SolarIconsData bookMinimalistic =
-      SolarIconsData(0xec59, fontFamily: _fontFamily);
-  static const SolarIconsData book =
-      SolarIconsData(0xec5a, fontFamily: _fontFamily);
-  static const SolarIconsData bookmarkCircle =
-      SolarIconsData(0xec5b, fontFamily: _fontFamily);
-  static const SolarIconsData bookmarkOpened =
-      SolarIconsData(0xec5c, fontFamily: _fontFamily);
-  static const SolarIconsData bookmarkSquareMinimalistic =
-      SolarIconsData(0xec5d, fontFamily: _fontFamily);
-  static const SolarIconsData bookmarkSquare =
-      SolarIconsData(0xec5e, fontFamily: _fontFamily);
-  static const SolarIconsData bookmark =
-      SolarIconsData(0xec5f, fontFamily: _fontFamily);
-  static const SolarIconsData calculatorMinimalistic =
-      SolarIconsData(0xec60, fontFamily: _fontFamily);
-  static const SolarIconsData calculator =
-      SolarIconsData(0xec61, fontFamily: _fontFamily);
-  static const SolarIconsData caseMinimalistic =
-      SolarIconsData(0xec62, fontFamily: _fontFamily);
-  static const SolarIconsData caseRoundMinimalistic =
-      SolarIconsData(0xec63, fontFamily: _fontFamily);
-  static const SolarIconsData diplomaVerified =
-      SolarIconsData(0xec64, fontFamily: _fontFamily);
-  static const SolarIconsData diploma =
-      SolarIconsData(0xec65, fontFamily: _fontFamily);
-  static const SolarIconsData document =
-      SolarIconsData(0xec66, fontFamily: _fontFamily);
-  static const SolarIconsData notebookBookmark =
-      SolarIconsData(0xec67, fontFamily: _fontFamily);
-  static const SolarIconsData notebookMinimalistic =
-      SolarIconsData(0xec68, fontFamily: _fontFamily);
-  static const SolarIconsData notebookSquare =
-      SolarIconsData(0xec69, fontFamily: _fontFamily);
-  static const SolarIconsData notebook =
-      SolarIconsData(0xec6a, fontFamily: _fontFamily);
-  static const SolarIconsData passportMinimalistic =
-      SolarIconsData(0xec6b, fontFamily: _fontFamily);
-  static const SolarIconsData passport =
-      SolarIconsData(0xec6c, fontFamily: _fontFamily);
-  static const SolarIconsData plus =
-      SolarIconsData(0xec6d, fontFamily: _fontFamily);
-  static const SolarIconsData minus =
-      SolarIconsData(0xec6d, fontFamily: _fontFamily);
-  static const SolarIconsData ovenMittsMinimalistic =
-      SolarIconsData(0xec6e, fontFamily: _fontFamily);
-  static const SolarIconsData bottle =
-      SolarIconsData(0xec6f, fontFamily: _fontFamily);
-  static const SolarIconsData chefHatHeart =
-      SolarIconsData(0xec70, fontFamily: _fontFamily);
-  static const SolarIconsData chefHatMinimalistic =
-      SolarIconsData(0xec71, fontFamily: _fontFamily);
-  static const SolarIconsData chefHat =
-      SolarIconsData(0xec72, fontFamily: _fontFamily);
-  static const SolarIconsData corkscrew =
-      SolarIconsData(0xec73, fontFamily: _fontFamily);
-  static const SolarIconsData cupHot =
-      SolarIconsData(0xec74, fontFamily: _fontFamily);
-  static const SolarIconsData cupPaper =
-      SolarIconsData(0xec75, fontFamily: _fontFamily);
-  static const SolarIconsData cup =
-      SolarIconsData(0xec76, fontFamily: _fontFamily);
-  static const SolarIconsData donutBitten =
-      SolarIconsData(0xec77, fontFamily: _fontFamily);
-  static const SolarIconsData donut =
-      SolarIconsData(0xec78, fontFamily: _fontFamily);
-  static const SolarIconsData ladle =
-      SolarIconsData(0xec79, fontFamily: _fontFamily);
-  static const SolarIconsData ovenMitts =
-      SolarIconsData(0xec7a, fontFamily: _fontFamily);
-  static const SolarIconsData rollingPin =
-      SolarIconsData(0xec7b, fontFamily: _fontFamily);
-  static const SolarIconsData teaCup =
-      SolarIconsData(0xec7c, fontFamily: _fontFamily);
-  static const SolarIconsData whisk =
-      SolarIconsData(0xec7d, fontFamily: _fontFamily);
-  static const SolarIconsData wineglassTriangle =
-      SolarIconsData(0xec7e, fontFamily: _fontFamily);
-  static const SolarIconsData wineglass =
-      SolarIconsData(0xec7f, fontFamily: _fontFamily);
-  static const SolarIconsData alignBottom =
-      SolarIconsData(0xec80, fontFamily: _fontFamily);
-  static const SolarIconsData alignHorizontalSpacing =
-      SolarIconsData(0xec81, fontFamily: _fontFamily);
-  static const SolarIconsData alignHorizontalCenter =
-      SolarIconsData(0xec82, fontFamily: _fontFamily);
-  static const SolarIconsData alignLeft =
-      SolarIconsData(0xec83, fontFamily: _fontFamily);
-  static const SolarIconsData alignRight =
-      SolarIconsData(0xec84, fontFamily: _fontFamily);
-  static const SolarIconsData alignTop =
-      SolarIconsData(0xec85, fontFamily: _fontFamily);
-  static const SolarIconsData alignVerticalCenter =
-      SolarIconsData(0xec86, fontFamily: _fontFamily);
-  static const SolarIconsData alignVerticalSpacing =
-      SolarIconsData(0xec87, fontFamily: _fontFamily);
-  static const SolarIconsData paintRoller =
-      SolarIconsData(0xec88, fontFamily: _fontFamily);
-  static const SolarIconsData colourTuning =
-      SolarIconsData(0xec89, fontFamily: _fontFamily);
-  static const SolarIconsData cropMinimalistic =
-      SolarIconsData(0xec8a, fontFamily: _fontFamily);
-  static const SolarIconsData crop =
-      SolarIconsData(0xec8b, fontFamily: _fontFamily);
-  static const SolarIconsData filters =
-      SolarIconsData(0xec8c, fontFamily: _fontFamily);
-  static const SolarIconsData flipHorizontal =
-      SolarIconsData(0xec8d, fontFamily: _fontFamily);
-  static const SolarIconsData flipVertical =
-      SolarIconsData(0xec8e, fontFamily: _fontFamily);
-  static const SolarIconsData layersMinimalistic =
-      SolarIconsData(0xec8f, fontFamily: _fontFamily);
-  static const SolarIconsData layers =
-      SolarIconsData(0xec90, fontFamily: _fontFamily);
-  static const SolarIconsData mirrorLeft =
-      SolarIconsData(0xec91, fontFamily: _fontFamily);
-  static const SolarIconsData mirrorRight =
-      SolarIconsData(0xec92, fontFamily: _fontFamily);
-  static const SolarIconsData paletteRound =
-      SolarIconsData(0xec93, fontFamily: _fontFamily);
-  static const SolarIconsData palette =
-      SolarIconsData(0xec94, fontFamily: _fontFamily);
-  static const SolarIconsData palette2 =
-      SolarIconsData(0xec95, fontFamily: _fontFamily);
-  static const SolarIconsData pipette =
-      SolarIconsData(0xec96, fontFamily: _fontFamily);
-  static const SolarIconsData radialBlur =
-      SolarIconsData(0xec97, fontFamily: _fontFamily);
-  static const SolarIconsData rulerAngular =
-      SolarIconsData(0xec98, fontFamily: _fontFamily);
-  static const SolarIconsData rulerCrossPen =
-      SolarIconsData(0xec99, fontFamily: _fontFamily);
-  static const SolarIconsData rulerPen =
-      SolarIconsData(0xec9a, fontFamily: _fontFamily);
-  static const SolarIconsData ruler =
-      SolarIconsData(0xec9b, fontFamily: _fontFamily);
-  static const SolarIconsData threeSquares =
-      SolarIconsData(0xec9c, fontFamily: _fontFamily);
-  static const SolarIconsData dislike =
-      SolarIconsData(0xec9d, fontFamily: _fontFamily);
-  static const SolarIconsData heartAngle =
-      SolarIconsData(0xec9e, fontFamily: _fontFamily);
-  static const SolarIconsData heartBroken =
-      SolarIconsData(0xec9f, fontFamily: _fontFamily);
-  static const SolarIconsData heartLock =
-      SolarIconsData(0xeca0, fontFamily: _fontFamily);
-  static const SolarIconsData heartShine =
-      SolarIconsData(0xeca1, fontFamily: _fontFamily);
-  static const SolarIconsData heartUnlock =
-      SolarIconsData(0xeca2, fontFamily: _fontFamily);
-  static const SolarIconsData heart =
-      SolarIconsData(0xeca3, fontFamily: _fontFamily);
-  static const SolarIconsData hearts =
-      SolarIconsData(0xeca4, fontFamily: _fontFamily);
-  static const SolarIconsData like =
-      SolarIconsData(0xeca5, fontFamily: _fontFamily);
-  static const SolarIconsData medalRibbonStar =
-      SolarIconsData(0xeca6, fontFamily: _fontFamily);
-  static const SolarIconsData medalRibbon =
-      SolarIconsData(0xeca7, fontFamily: _fontFamily);
-  static const SolarIconsData medalRibbonsStart =
-      SolarIconsData(0xeca8, fontFamily: _fontFamily);
-  static const SolarIconsData medalStarCircle =
-      SolarIconsData(0xeca9, fontFamily: _fontFamily);
-  static const SolarIconsData medalStarSquare =
-      SolarIconsData(0xecaa, fontFamily: _fontFamily);
-  static const SolarIconsData medalStar =
-      SolarIconsData(0xecab, fontFamily: _fontFamily);
-  static const SolarIconsData startShine =
-      SolarIconsData(0xecac, fontFamily: _fontFamily);
-  static const SolarIconsData start1 =
-      SolarIconsData(0xecad, fontFamily: _fontFamily);
-  static const SolarIconsData archiveCheck =
-      SolarIconsData(0xecae, fontFamily: _fontFamily);
-  static const SolarIconsData archiveDownMinimalistic =
-      SolarIconsData(0xecaf, fontFamily: _fontFamily);
-  static const SolarIconsData archiveDown =
-      SolarIconsData(0xecb0, fontFamily: _fontFamily);
-  static const SolarIconsData archiveMinimalistic =
-      SolarIconsData(0xecb1, fontFamily: _fontFamily);
-  static const SolarIconsData archiveUpMinimalistic =
-      SolarIconsData(0xecb2, fontFamily: _fontFamily);
-  static const SolarIconsData archiveUp =
-      SolarIconsData(0xecb3, fontFamily: _fontFamily);
-  static const SolarIconsData archive =
-      SolarIconsData(0xecb4, fontFamily: _fontFamily);
-  static const SolarIconsData clipboardAdd =
-      SolarIconsData(0xecb5, fontFamily: _fontFamily);
-  static const SolarIconsData clipboardCheck =
-      SolarIconsData(0xecb6, fontFamily: _fontFamily);
-  static const SolarIconsData clipboardHeart =
-      SolarIconsData(0xecb7, fontFamily: _fontFamily);
-  static const SolarIconsData clipboardList =
-      SolarIconsData(0xecb8, fontFamily: _fontFamily);
-  static const SolarIconsData clipboardRemove =
-      SolarIconsData(0xecb9, fontFamily: _fontFamily);
-  static const SolarIconsData clipboardText =
-      SolarIconsData(0xecba, fontFamily: _fontFamily);
-  static const SolarIconsData clipboard =
-      SolarIconsData(0xecbb, fontFamily: _fontFamily);
-  static const SolarIconsData documentAdd =
-      SolarIconsData(0xecbc, fontFamily: _fontFamily);
-  static const SolarIconsData documentMedicine =
-      SolarIconsData(0xecbd, fontFamily: _fontFamily);
-  static const SolarIconsData documentText =
-      SolarIconsData(0xecbe, fontFamily: _fontFamily);
-  static const SolarIconsData document1 =
-      SolarIconsData(0xecbf, fontFamily: _fontFamily);
-  static const SolarIconsData documentsMinimalistic =
-      SolarIconsData(0xecc0, fontFamily: _fontFamily);
-  static const SolarIconsData documents =
-      SolarIconsData(0xecc1, fontFamily: _fontFamily);
-  static const SolarIconsData notebook1 =
-      SolarIconsData(0xecc2, fontFamily: _fontFamily);
-  static const SolarIconsData notesMinimalistic =
-      SolarIconsData(0xecc3, fontFamily: _fontFamily);
-  static const SolarIconsData notes =
-      SolarIconsData(0xecc4, fontFamily: _fontFamily);
-  static const SolarIconsData arrowToDownRight =
-      SolarIconsData(0xecc5, fontFamily: _fontFamily);
-  static const SolarIconsData arrowToTopLeft =
-      SolarIconsData(0xecc6, fontFamily: _fontFamily);
-  static const SolarIconsData arrowToTopRight =
-      SolarIconsData(0xecc7, fontFamily: _fontFamily);
-  static const SolarIconsData arrowToDownLeft =
-      SolarIconsData(0xecc8, fontFamily: _fontFamily);
-  static const SolarIconsData downloadMinimalistic =
-      SolarIconsData(0xecc9, fontFamily: _fontFamily);
-  static const SolarIconsData download =
-      SolarIconsData(0xecca, fontFamily: _fontFamily);
-  static const SolarIconsData exit =
-      SolarIconsData(0xeccb, fontFamily: _fontFamily);
-  static const SolarIconsData export =
-      SolarIconsData(0xeccc, fontFamily: _fontFamily);
-  static const SolarIconsData forward_2 =
-      SolarIconsData(0xeccd, fontFamily: _fontFamily);
-  static const SolarIconsData forward1 =
-      SolarIconsData(0xecce, fontFamily: _fontFamily);
-  static const SolarIconsData import =
-      SolarIconsData(0xeccf, fontFamily: _fontFamily);
-  static const SolarIconsData login_2 =
-      SolarIconsData(0xecd0, fontFamily: _fontFamily);
-  static const SolarIconsData login_3 =
-      SolarIconsData(0xecd1, fontFamily: _fontFamily);
-  static const SolarIconsData login =
-      SolarIconsData(0xecd2, fontFamily: _fontFamily);
-  static const SolarIconsData logout_2 =
-      SolarIconsData(0xecd3, fontFamily: _fontFamily);
-  static const SolarIconsData logout_3 =
-      SolarIconsData(0xecd4, fontFamily: _fontFamily);
-  static const SolarIconsData logout =
-      SolarIconsData(0xecd5, fontFamily: _fontFamily);
-  static const SolarIconsData maximizeSquare2 =
-      SolarIconsData(0xecd6, fontFamily: _fontFamily);
-  static const SolarIconsData minimizeSquare2 =
-      SolarIconsData(0xecd7, fontFamily: _fontFamily);
-  static const SolarIconsData minimizeSquareMinimalistic =
-      SolarIconsData(0xecd8, fontFamily: _fontFamily);
-  static const SolarIconsData reply_2 =
-      SolarIconsData(0xecd9, fontFamily: _fontFamily);
-  static const SolarIconsData reply =
-      SolarIconsData(0xecda, fontFamily: _fontFamily);
-  static const SolarIconsData screenShare =
-      SolarIconsData(0xecdb, fontFamily: _fontFamily);
-  static const SolarIconsData uploadMinimalistic =
-      SolarIconsData(0xecdc, fontFamily: _fontFamily);
-  static const SolarIconsData upload =
-      SolarIconsData(0xecdd, fontFamily: _fontFamily);
-  static const SolarIconsData circleBottomDown =
-      SolarIconsData(0xecde, fontFamily: _fontFamily);
-  static const SolarIconsData circleBottomUp =
-      SolarIconsData(0xecdf, fontFamily: _fontFamily);
-  static const SolarIconsData circleTopDown =
-      SolarIconsData(0xece0, fontFamily: _fontFamily);
-  static const SolarIconsData circleTopUp =
-      SolarIconsData(0xece1, fontFamily: _fontFamily);
-  static const SolarIconsData maximizeSquare3 =
-      SolarIconsData(0xece2, fontFamily: _fontFamily);
-  static const SolarIconsData maximizeSquareMinimalistic =
-      SolarIconsData(0xece3, fontFamily: _fontFamily);
-  static const SolarIconsData maximizeSquare =
-      SolarIconsData(0xece4, fontFamily: _fontFamily);
-  static const SolarIconsData maximize =
-      SolarIconsData(0xece5, fontFamily: _fontFamily);
-  static const SolarIconsData minimizeSquare3 =
-      SolarIconsData(0xece6, fontFamily: _fontFamily);
-  static const SolarIconsData minimizeSquare =
-      SolarIconsData(0xece7, fontFamily: _fontFamily);
-  static const SolarIconsData minimize =
-      SolarIconsData(0xece8, fontFamily: _fontFamily);
-  static const SolarIconsData reorder =
-      SolarIconsData(0xece9, fontFamily: _fontFamily);
-  static const SolarIconsData scale =
-      SolarIconsData(0xecea, fontFamily: _fontFamily);
-  static const SolarIconsData squareBottomDown =
-      SolarIconsData(0xeceb, fontFamily: _fontFamily);
-  static const SolarIconsData squareBottomUp =
-      SolarIconsData(0xecec, fontFamily: _fontFamily);
-  static const SolarIconsData squareTopDown =
-      SolarIconsData(0xeced, fontFamily: _fontFamily);
-  static const SolarIconsData squareTopUp =
-      SolarIconsData(0xecee, fontFamily: _fontFamily);
-  static const SolarIconsData undoLeftRoundSquare =
-      SolarIconsData(0xecef, fontFamily: _fontFamily);
-  static const SolarIconsData undoLeftRound =
-      SolarIconsData(0xecf0, fontFamily: _fontFamily);
-  static const SolarIconsData undoLeftSquare =
-      SolarIconsData(0xecf1, fontFamily: _fontFamily);
-  static const SolarIconsData undoLeft =
-      SolarIconsData(0xecf2, fontFamily: _fontFamily);
-  static const SolarIconsData undoRightRoundSquare =
-      SolarIconsData(0xecf3, fontFamily: _fontFamily);
-  static const SolarIconsData undoRightRound =
-      SolarIconsData(0xecf4, fontFamily: _fontFamily);
-  static const SolarIconsData undoRightSquare =
-      SolarIconsData(0xecf5, fontFamily: _fontFamily);
-  static const SolarIconsData undoRight =
-      SolarIconsData(0xecf6, fontFamily: _fontFamily);
-  static const SolarIconsData downloadSquare =
-      SolarIconsData(0xecf7, fontFamily: _fontFamily);
-  static const SolarIconsData downloadTwiceSquare =
-      SolarIconsData(0xecf8, fontFamily: _fontFamily);
-  static const SolarIconsData receiveSquare =
-      SolarIconsData(0xecf9, fontFamily: _fontFamily);
-  static const SolarIconsData receiveTwiceSquare =
-      SolarIconsData(0xecfa, fontFamily: _fontFamily);
-  static const SolarIconsData sendSquare =
-      SolarIconsData(0xecfb, fontFamily: _fontFamily);
-  static const SolarIconsData sendTwiceSquare =
-      SolarIconsData(0xecfc, fontFamily: _fontFamily);
-  static const SolarIconsData uploadSquare =
-      SolarIconsData(0xecfd, fontFamily: _fontFamily);
-  static const SolarIconsData uploadTwiceSquare =
-      SolarIconsData(0xecfe, fontFamily: _fontFamily);
-  static const SolarIconsData bellBing =
-      SolarIconsData(0xecff, fontFamily: _fontFamily);
-  static const SolarIconsData bellOff =
-      SolarIconsData(0xed00, fontFamily: _fontFamily);
-  static const SolarIconsData bell =
-      SolarIconsData(0xed01, fontFamily: _fontFamily);
-  static const SolarIconsData notificationLinesRemove =
-      SolarIconsData(0xed02, fontFamily: _fontFamily);
-  static const SolarIconsData notificationRemove =
-      SolarIconsData(0xed03, fontFamily: _fontFamily);
-  static const SolarIconsData notificationUnreadLines =
-      SolarIconsData(0xed04, fontFamily: _fontFamily);
-  static const SolarIconsData notificationUnread =
-      SolarIconsData(0xed05, fontFamily: _fontFamily);
-  static const SolarIconsData codeScan =
-      SolarIconsData(0xed06, fontFamily: _fontFamily);
-  static const SolarIconsData eyeScan =
-      SolarIconsData(0xed07, fontFamily: _fontFamily);
-  static const SolarIconsData incognito =
-      SolarIconsData(0xed08, fontFamily: _fontFamily);
-  static const SolarIconsData keyMinimalistic2 =
-      SolarIconsData(0xed09, fontFamily: _fontFamily);
-  static const SolarIconsData keyMinimalisticSquare_2 =
-      SolarIconsData(0xed0a, fontFamily: _fontFamily);
-  static const SolarIconsData keyMinimalisticSquare_3 =
-      SolarIconsData(0xed0b, fontFamily: _fontFamily);
-  static const SolarIconsData keyMinimalisticSquare =
-      SolarIconsData(0xed0c, fontFamily: _fontFamily);
-  static const SolarIconsData keyMinimalistic =
-      SolarIconsData(0xed0d, fontFamily: _fontFamily);
-  static const SolarIconsData objectScan =
-      SolarIconsData(0xed0e, fontFamily: _fontFamily);
-  static const SolarIconsData qrCode =
-      SolarIconsData(0xed0f, fontFamily: _fontFamily);
-  static const SolarIconsData scanner_2 =
-      SolarIconsData(0xed10, fontFamily: _fontFamily);
-  static const SolarIconsData scanner =
-      SolarIconsData(0xed11, fontFamily: _fontFamily);
-  static const SolarIconsData shieldCheck =
-      SolarIconsData(0xed12, fontFamily: _fontFamily);
-  static const SolarIconsData shieldCross =
-      SolarIconsData(0xed13, fontFamily: _fontFamily);
-  static const SolarIconsData shieldKeyholeMinimalistic =
-      SolarIconsData(0xed14, fontFamily: _fontFamily);
-  static const SolarIconsData shieldKeyhole =
-      SolarIconsData(0xed15, fontFamily: _fontFamily);
-  static const SolarIconsData shieldMinimalistic =
-      SolarIconsData(0xed16, fontFamily: _fontFamily);
-  static const SolarIconsData shieldMinus =
-      SolarIconsData(0xed17, fontFamily: _fontFamily);
-  static const SolarIconsData shieldNetwork =
-      SolarIconsData(0xed18, fontFamily: _fontFamily);
-  static const SolarIconsData shieldPlus =
-      SolarIconsData(0xed19, fontFamily: _fontFamily);
-  static const SolarIconsData shieldStar =
-      SolarIconsData(0xed1a, fontFamily: _fontFamily);
-  static const SolarIconsData shieldUp =
-      SolarIconsData(0xed1b, fontFamily: _fontFamily);
-  static const SolarIconsData shieldUser =
-      SolarIconsData(0xed1c, fontFamily: _fontFamily);
-  static const SolarIconsData shieldWarning =
-      SolarIconsData(0xed1d, fontFamily: _fontFamily);
-  static const SolarIconsData shield =
-      SolarIconsData(0xed1e, fontFamily: _fontFamily);
-  static const SolarIconsData bombEmoji =
-      SolarIconsData(0xed1f, fontFamily: _fontFamily);
-  static const SolarIconsData bombMinimalistic =
-      SolarIconsData(0xed20, fontFamily: _fontFamily);
-  static const SolarIconsData bomb =
-      SolarIconsData(0xed21, fontFamily: _fontFamily);
-  static const SolarIconsData eyeClosed =
-      SolarIconsData(0xed22, fontFamily: _fontFamily);
-  static const SolarIconsData eye =
-      SolarIconsData(0xed23, fontFamily: _fontFamily);
-  static const SolarIconsData keySquare_2 =
-      SolarIconsData(0xed24, fontFamily: _fontFamily);
-  static const SolarIconsData keySquare =
-      SolarIconsData(0xed25, fontFamily: _fontFamily);
-  static const SolarIconsData key =
-      SolarIconsData(0xed26, fontFamily: _fontFamily);
-  static const SolarIconsData lockKeyholeMinimalisticUnlocked =
-      SolarIconsData(0xed27, fontFamily: _fontFamily);
-  static const SolarIconsData lockKeyholeMinimalistic =
-      SolarIconsData(0xed28, fontFamily: _fontFamily);
-  static const SolarIconsData lockKeyholeUnlocked =
-      SolarIconsData(0xed29, fontFamily: _fontFamily);
-  static const SolarIconsData lockKeyhole =
-      SolarIconsData(0xed2a, fontFamily: _fontFamily);
-  static const SolarIconsData lockPassword_ =
-      SolarIconsData(0xed2b, fontFamily: _fontFamily);
-  static const SolarIconsData lockPassword =
-      SolarIconsData(0xed2c, fontFamily: _fontFamily);
-  static const SolarIconsData lockUnlocked =
-      SolarIconsData(0xed2d, fontFamily: _fontFamily);
-  static const SolarIconsData lock =
-      SolarIconsData(0xed2e, fontFamily: _fontFamily);
-  static const SolarIconsData passwordMinimalisticInput =
-      SolarIconsData(0xed2f, fontFamily: _fontFamily);
-  static const SolarIconsData passwordMinimalistic =
-      SolarIconsData(0xed30, fontFamily: _fontFamily);
-  static const SolarIconsData password =
-      SolarIconsData(0xed31, fontFamily: _fontFamily);
-  static const SolarIconsData sirenRounded =
-      SolarIconsData(0xed32, fontFamily: _fontFamily);
-  static const SolarIconsData siren =
-      SolarIconsData(0xed33, fontFamily: _fontFamily);
-  static const SolarIconsData userBlockRounded =
-      SolarIconsData(0xed34, fontFamily: _fontFamily);
-  static const SolarIconsData userBlock =
-      SolarIconsData(0xed35, fontFamily: _fontFamily);
-  static const SolarIconsData userCheck =
-      SolarIconsData(0xed36, fontFamily: _fontFamily);
-  static const SolarIconsData userCircle =
-      SolarIconsData(0xed37, fontFamily: _fontFamily);
-  static const SolarIconsData userCrossRounded =
-      SolarIconsData(0xed38, fontFamily: _fontFamily);
-  static const SolarIconsData userCross =
-      SolarIconsData(0xed39, fontFamily: _fontFamily);
-  static const SolarIconsData userHandUp =
-      SolarIconsData(0xed3a, fontFamily: _fontFamily);
-  static const SolarIconsData userHands =
-      SolarIconsData(0xed3b, fontFamily: _fontFamily);
-  static const SolarIconsData userHeartRounded =
-      SolarIconsData(0xed3c, fontFamily: _fontFamily);
-  static const SolarIconsData userHeart =
-      SolarIconsData(0xed3d, fontFamily: _fontFamily);
-  static const SolarIconsData userId =
-      SolarIconsData(0xed3e, fontFamily: _fontFamily);
-  static const SolarIconsData userMinusRounded =
-      SolarIconsData(0xed3f, fontFamily: _fontFamily);
-  static const SolarIconsData userMinus =
-      SolarIconsData(0xed40, fontFamily: _fontFamily);
-  static const SolarIconsData userPlusRounded =
-      SolarIconsData(0xed41, fontFamily: _fontFamily);
-  static const SolarIconsData userPlus =
-      SolarIconsData(0xed42, fontFamily: _fontFamily);
-  static const SolarIconsData userSpeakRounded =
-      SolarIconsData(0xed43, fontFamily: _fontFamily);
-  static const SolarIconsData userSpeak =
-      SolarIconsData(0xed44, fontFamily: _fontFamily);
-  static const SolarIconsData user =
-      SolarIconsData(0xed45, fontFamily: _fontFamily);
-  static const SolarIconsData userCheckRounded =
-      SolarIconsData(0xed46, fontFamily: _fontFamily);
-  static const SolarIconsData userRounded =
-      SolarIconsData(0xed47, fontFamily: _fontFamily);
-  static const SolarIconsData usersGroupRounded =
-      SolarIconsData(0xed48, fontFamily: _fontFamily);
-  static const SolarIconsData usersGroupTwoRounded =
-      SolarIconsData(0xed49, fontFamily: _fontFamily);
-  static const SolarIconsData handHeart =
-      SolarIconsData(0xed4a, fontFamily: _fontFamily);
-  static const SolarIconsData handMoney =
-      SolarIconsData(0xed4b, fontFamily: _fontFamily);
-  static const SolarIconsData handPills =
-      SolarIconsData(0xed4c, fontFamily: _fontFamily);
-  static const SolarIconsData handShake =
-      SolarIconsData(0xed4d, fontFamily: _fontFamily);
-  static const SolarIconsData handStars =
-      SolarIconsData(0xed4e, fontFamily: _fontFamily);
-  static const SolarIconsData accessibility =
-      SolarIconsData(0xed4f, fontFamily: _fontFamily);
-  static const SolarIconsData body =
-      SolarIconsData(0xed50, fontFamily: _fontFamily);
-  static const SolarIconsData hanger_2 =
-      SolarIconsData(0xed51, fontFamily: _fontFamily);
-  static const SolarIconsData hanger =
-      SolarIconsData(0xed52, fontFamily: _fontFamily);
-  static const SolarIconsData maskHapply =
-      SolarIconsData(0xed53, fontFamily: _fontFamily);
-  static const SolarIconsData maskSad =
-      SolarIconsData(0xed54, fontFamily: _fontFamily);
-  static const SolarIconsData masks =
-      SolarIconsData(0xed55, fontFamily: _fontFamily);
-  static const SolarIconsData mentionCircle =
-      SolarIconsData(0xed56, fontFamily: _fontFamily);
-  static const SolarIconsData mentionSquare =
-      SolarIconsData(0xed57, fontFamily: _fontFamily);
-  static const SolarIconsData skirt =
-      SolarIconsData(0xed58, fontFamily: _fontFamily);
-  static const SolarIconsData tShirt =
-      SolarIconsData(0xed59, fontFamily: _fontFamily);
-  static const SolarIconsData boxMinimalistic =
-      SolarIconsData(0xed5a, fontFamily: _fontFamily);
-  static const SolarIconsData box =
-      SolarIconsData(0xed5b, fontFamily: _fontFamily);
-  static const SolarIconsData confettiMinimalistic =
-      SolarIconsData(0xed5c, fontFamily: _fontFamily);
-  static const SolarIconsData confetti =
-      SolarIconsData(0xed5d, fontFamily: _fontFamily);
-  static const SolarIconsData cosmetic =
-      SolarIconsData(0xed5e, fontFamily: _fontFamily);
-  static const SolarIconsData cursorSquare =
-      SolarIconsData(0xed5f, fontFamily: _fontFamily);
-  static const SolarIconsData cursor =
-      SolarIconsData(0xed60, fontFamily: _fontFamily);
-  static const SolarIconsData delivery =
-      SolarIconsData(0xed61, fontFamily: _fontFamily);
-  static const SolarIconsData feed =
-      SolarIconsData(0xed62, fontFamily: _fontFamily);
-  static const SolarIconsData ferrisWheel =
-      SolarIconsData(0xed63, fontFamily: _fontFamily);
-  static const SolarIconsData flashlightOn =
-      SolarIconsData(0xed64, fontFamily: _fontFamily);
-  static const SolarIconsData flashlight =
-      SolarIconsData(0xed65, fontFamily: _fontFamily);
-  static const SolarIconsData gift =
-      SolarIconsData(0xed66, fontFamily: _fontFamily);
-  static const SolarIconsData glasses =
-      SolarIconsData(0xed67, fontFamily: _fontFamily);
-  static const SolarIconsData magicStick_2 =
-      SolarIconsData(0xed68, fontFamily: _fontFamily);
-  static const SolarIconsData magicStick_3 =
-      SolarIconsData(0xed69, fontFamily: _fontFamily);
-  static const SolarIconsData magicStick =
-      SolarIconsData(0xed6a, fontFamily: _fontFamily);
-  static const SolarIconsData magnetWave =
-      SolarIconsData(0xed6b, fontFamily: _fontFamily);
-  static const SolarIconsData magnet =
-      SolarIconsData(0xed6c, fontFamily: _fontFamily);
-  static const SolarIconsData mirror1 =
-      SolarIconsData(0xed6d, fontFamily: _fontFamily);
-  static const SolarIconsData perfume =
-      SolarIconsData(0xed6e, fontFamily: _fontFamily);
-  static const SolarIconsData scissorsSquare =
-      SolarIconsData(0xed6f, fontFamily: _fontFamily);
-  static const SolarIconsData scissors =
-      SolarIconsData(0xed70, fontFamily: _fontFamily);
-  static const SolarIconsData sledgehammer =
-      SolarIconsData(0xed71, fontFamily: _fontFamily);
-  static const SolarIconsData sleeping =
-      SolarIconsData(0xed72, fontFamily: _fontFamily);
-  static const SolarIconsData k =
-      SolarIconsData(0xed73, fontFamily: _fontFamily);
-  static const SolarIconsData augmentedReality =
-      SolarIconsData(0xed74, fontFamily: _fontFamily);
-  static const SolarIconsData balloon =
-      SolarIconsData(0xed75, fontFamily: _fontFamily);
-  static const SolarIconsData copyright =
-      SolarIconsData(0xed76, fontFamily: _fontFamily);
-  static const SolarIconsData creativeCommons =
-      SolarIconsData(0xed77, fontFamily: _fontFamily);
-  static const SolarIconsData cupFirst =
-      SolarIconsData(0xed78, fontFamily: _fontFamily);
-  static const SolarIconsData cupMusic =
-      SolarIconsData(0xed79, fontFamily: _fontFamily);
-  static const SolarIconsData cupStar =
-      SolarIconsData(0xed7a, fontFamily: _fontFamily);
-  static const SolarIconsData cup1 =
-      SolarIconsData(0xed7b, fontFamily: _fontFamily);
-  static const SolarIconsData explicit =
-      SolarIconsData(0xed7c, fontFamily: _fontFamily);
-  static const SolarIconsData filter =
-      SolarIconsData(0xed7d, fontFamily: _fontFamily);
-  static const SolarIconsData flag_2 =
-      SolarIconsData(0xed7e, fontFamily: _fontFamily);
-  static const SolarIconsData flag =
-      SolarIconsData(0xed7f, fontFamily: _fontFamily);
-  static const SolarIconsData hamburgerMenu =
-      SolarIconsData(0xed80, fontFamily: _fontFamily);
-  static const SolarIconsData highDefinition =
-      SolarIconsData(0xed81, fontFamily: _fontFamily);
-  static const SolarIconsData highQuality =
-      SolarIconsData(0xed82, fontFamily: _fontFamily);
-  static const SolarIconsData paperBin =
-      SolarIconsData(0xed83, fontFamily: _fontFamily);
-  static const SolarIconsData paw =
-      SolarIconsData(0xed84, fontFamily: _fontFamily);
-  static const SolarIconsData reorder1 =
-      SolarIconsData(0xed85, fontFamily: _fontFamily);
-  static const SolarIconsData sort =
-      SolarIconsData(0xed86, fontFamily: _fontFamily);
-  static const SolarIconsData specialEffects =
-      SolarIconsData(0xed87, fontFamily: _fontFamily);
-  static const SolarIconsData xxx =
-      SolarIconsData(0xed88, fontFamily: _fontFamily);
-  static const SolarIconsData boltCircle =
-      SolarIconsData(0xed89, fontFamily: _fontFamily);
-  static const SolarIconsData bolt =
-      SolarIconsData(0xed8a, fontFamily: _fontFamily);
-  static const SolarIconsData broom =
-      SolarIconsData(0xed8b, fontFamily: _fontFamily);
-  static const SolarIconsData cat =
-      SolarIconsData(0xed8c, fontFamily: _fontFamily);
-  static const SolarIconsData copy =
-      SolarIconsData(0xed8d, fontFamily: _fontFamily);
-  static const SolarIconsData figma =
-      SolarIconsData(0xed8e, fontFamily: _fontFamily);
-  static const SolarIconsData fuel =
-      SolarIconsData(0xed8f, fontFamily: _fontFamily);
-  static const SolarIconsData ghostSmile =
-      SolarIconsData(0xed90, fontFamily: _fontFamily);
-  static const SolarIconsData ghost =
-      SolarIconsData(0xed91, fontFamily: _fontFamily);
-  static const SolarIconsData help =
-      SolarIconsData(0xed92, fontFamily: _fontFamily);
-  static const SolarIconsData plate =
-      SolarIconsData(0xed93, fontFamily: _fontFamily);
-  static const SolarIconsData postsCarouselHorizontal =
-      SolarIconsData(0xed94, fontFamily: _fontFamily);
-  static const SolarIconsData postsCarouselVertical =
-      SolarIconsData(0xed95, fontFamily: _fontFamily);
-  static const SolarIconsData power =
-      SolarIconsData(0xed96, fontFamily: _fontFamily);
-  static const SolarIconsData shareCircle =
-      SolarIconsData(0xed97, fontFamily: _fontFamily);
-  static const SolarIconsData share =
-      SolarIconsData(0xed98, fontFamily: _fontFamily);
-  static const SolarIconsData subtitles =
-      SolarIconsData(0xed99, fontFamily: _fontFamily);
-  static const SolarIconsData target =
-      SolarIconsData(0xed9a, fontFamily: _fontFamily);
-  static const SolarIconsData trashBin2 =
-      SolarIconsData(0xed9b, fontFamily: _fontFamily);
-  static const SolarIconsData trashBinMinimalistic_2 =
-      SolarIconsData(0xed9c, fontFamily: _fontFamily);
-  static const SolarIconsData umbrella =
-      SolarIconsData(0xed9d, fontFamily: _fontFamily);
-  static const SolarIconsData waterdrop =
-      SolarIconsData(0xed9e, fontFamily: _fontFamily);
-  static const SolarIconsData winRar =
-      SolarIconsData(0xed9f, fontFamily: _fontFamily);
-  static const SolarIconsData batteryChargeMinimalistic =
-      SolarIconsData(0xeda0, fontFamily: _fontFamily);
-  static const SolarIconsData batteryCharge =
-      SolarIconsData(0xeda1, fontFamily: _fontFamily);
-  static const SolarIconsData batteryFullMinimalistic =
-      SolarIconsData(0xeda2, fontFamily: _fontFamily);
-  static const SolarIconsData batteryFull =
-      SolarIconsData(0xeda3, fontFamily: _fontFamily);
-  static const SolarIconsData batteryHalfMinimalistic =
-      SolarIconsData(0xeda4, fontFamily: _fontFamily);
-  static const SolarIconsData batteryHalf =
-      SolarIconsData(0xeda5, fontFamily: _fontFamily);
-  static const SolarIconsData batteryLowMinimalistic =
-      SolarIconsData(0xeda6, fontFamily: _fontFamily);
-  static const SolarIconsData batteryLow =
-      SolarIconsData(0xeda7, fontFamily: _fontFamily);
-  static const SolarIconsData crownLine =
-      SolarIconsData(0xeda8, fontFamily: _fontFamily);
-  static const SolarIconsData crownMinimalistic =
-      SolarIconsData(0xeda9, fontFamily: _fontFamily);
-  static const SolarIconsData crownStar =
-      SolarIconsData(0xedaa, fontFamily: _fontFamily);
-  static const SolarIconsData crown =
-      SolarIconsData(0xedab, fontFamily: _fontFamily);
-  static const SolarIconsData database =
-      SolarIconsData(0xedac, fontFamily: _fontFamily);
-  static const SolarIconsData homeWiFiAngle =
-      SolarIconsData(0xedad, fontFamily: _fontFamily);
-  static const SolarIconsData pinCircle =
-      SolarIconsData(0xedae, fontFamily: _fontFamily);
-  static const SolarIconsData pinList =
-      SolarIconsData(0xedaf, fontFamily: _fontFamily);
-  static const SolarIconsData pin =
-      SolarIconsData(0xedb0, fontFamily: _fontFamily);
-  static const SolarIconsData sliderHorizontal =
-      SolarIconsData(0xedb1, fontFamily: _fontFamily);
-  static const SolarIconsData sliderMinimalisticHorizontal =
-      SolarIconsData(0xedb2, fontFamily: _fontFamily);
-  static const SolarIconsData sliderVerticalMinimalistic =
-      SolarIconsData(0xedb3, fontFamily: _fontFamily);
-  static const SolarIconsData sliderVertical =
-      SolarIconsData(0xedb4, fontFamily: _fontFamily);
-  static const SolarIconsData smartHomeAngle =
-      SolarIconsData(0xedb5, fontFamily: _fontFamily);
-  static const SolarIconsData trafficEconomy =
-      SolarIconsData(0xedb6, fontFamily: _fontFamily);
-  static const SolarIconsData traffic =
-      SolarIconsData(0xedb7, fontFamily: _fontFamily);
-  static const SolarIconsData trashBinMinimalistic =
-      SolarIconsData(0xedb8, fontFamily: _fontFamily);
-  static const SolarIconsData trashBinTrash =
-      SolarIconsData(0xedb9, fontFamily: _fontFamily);
-  static const SolarIconsData addSquare =
-      SolarIconsData(0xedba, fontFamily: _fontFamily);
-  static const SolarIconsData checkSquare =
-      SolarIconsData(0xedbb, fontFamily: _fontFamily);
-  static const SolarIconsData closeSquare =
-      SolarIconsData(0xedbc, fontFamily: _fontFamily);
-  static const SolarIconsData dangerSquare =
-      SolarIconsData(0xedbd, fontFamily: _fontFamily);
-  static const SolarIconsData dangerTriangle =
-      SolarIconsData(0xedbe, fontFamily: _fontFamily);
-  static const SolarIconsData danger =
-      SolarIconsData(0xedbf, fontFamily: _fontFamily);
-  static const SolarIconsData forbiddenCircle =
-      SolarIconsData(0xedc0, fontFamily: _fontFamily);
-  static const SolarIconsData forbidden =
-      SolarIconsData(0xedc1, fontFamily: _fontFamily);
-  static const SolarIconsData home2 =
-      SolarIconsData(0xedc2, fontFamily: _fontFamily);
-  static const SolarIconsData homeAddAngle =
-      SolarIconsData(0xedc3, fontFamily: _fontFamily);
-  static const SolarIconsData homeAdd =
-      SolarIconsData(0xedc4, fontFamily: _fontFamily);
-  static const SolarIconsData homeAngle_2 =
-      SolarIconsData(0xedc5, fontFamily: _fontFamily);
-  static const SolarIconsData homeAngle =
-      SolarIconsData(0xedc6, fontFamily: _fontFamily);
-  static const SolarIconsData homeSmileAngle =
-      SolarIconsData(0xedc7, fontFamily: _fontFamily);
-  static const SolarIconsData homeSmile =
-      SolarIconsData(0xedc8, fontFamily: _fontFamily);
-  static const SolarIconsData homeWiFi =
-      SolarIconsData(0xedc9, fontFamily: _fontFamily);
-  static const SolarIconsData home =
-      SolarIconsData(0xedca, fontFamily: _fontFamily);
-  static const SolarIconsData infoCircle =
-      SolarIconsData(0xedcb, fontFamily: _fontFamily);
-  static const SolarIconsData infoSquare =
-      SolarIconsData(0xedcc, fontFamily: _fontFamily);
-  static const SolarIconsData menuDotsCircle =
-      SolarIconsData(0xedcd, fontFamily: _fontFamily);
-  static const SolarIconsData menuDotsSquare =
-      SolarIconsData(0xedce, fontFamily: _fontFamily);
-  static const SolarIconsData menuDots =
-      SolarIconsData(0xedcf, fontFamily: _fontFamily);
-  static const SolarIconsData minusCircle =
-      SolarIconsData(0xedd0, fontFamily: _fontFamily);
-  static const SolarIconsData minusSquare =
-      SolarIconsData(0xedd1, fontFamily: _fontFamily);
-  static const SolarIconsData questionSquare =
-      SolarIconsData(0xedd2, fontFamily: _fontFamily);
-  static const SolarIconsData revote =
-      SolarIconsData(0xedd3, fontFamily: _fontFamily);
-  static const SolarIconsData smartHome =
-      SolarIconsData(0xedd4, fontFamily: _fontFamily);
-  static const SolarIconsData addCircle =
-      SolarIconsData(0xedd5, fontFamily: _fontFamily);
-  static const SolarIconsData checkCircle =
-      SolarIconsData(0xedd6, fontFamily: _fontFamily);
-  static const SolarIconsData closeCircle =
-      SolarIconsData(0xedd7, fontFamily: _fontFamily);
-  static const SolarIconsData dangerCircle =
-      SolarIconsData(0xedd8, fontFamily: _fontFamily);
-  static const SolarIconsData questionCircle =
-      SolarIconsData(0xedd9, fontFamily: _fontFamily);
-  static const SolarIconsData buildings_2 =
-      SolarIconsData(0xedda, fontFamily: _fontFamily);
-  static const SolarIconsData buildings_3 =
-      SolarIconsData(0xeddb, fontFamily: _fontFamily);
-  static const SolarIconsData buildings =
-      SolarIconsData(0xeddc, fontFamily: _fontFamily);
-  static const SolarIconsData city =
-      SolarIconsData(0xeddd, fontFamily: _fontFamily);
-  static const SolarIconsData garage =
-      SolarIconsData(0xedde, fontFamily: _fontFamily);
-  static const SolarIconsData home1 =
-      SolarIconsData(0xeddf, fontFamily: _fontFamily);
-  static const SolarIconsData hospital =
-      SolarIconsData(0xede0, fontFamily: _fontFamily);
-  static const SolarIconsData bus =
-      SolarIconsData(0xede1, fontFamily: _fontFamily);
-  static const SolarIconsData electricRefueling =
-      SolarIconsData(0xede2, fontFamily: _fontFamily);
-  static const SolarIconsData gasStation =
-      SolarIconsData(0xede3, fontFamily: _fontFamily);
-  static const SolarIconsData kickScooter =
-      SolarIconsData(0xede4, fontFamily: _fontFamily);
-  static const SolarIconsData scooter =
-      SolarIconsData(0xede5, fontFamily: _fontFamily);
-  static const SolarIconsData speedometerLow =
-      SolarIconsData(0xede6, fontFamily: _fontFamily);
-  static const SolarIconsData speedometerMax =
-      SolarIconsData(0xede7, fontFamily: _fontFamily);
-  static const SolarIconsData speedometerMiddle =
-      SolarIconsData(0xede8, fontFamily: _fontFamily);
-  static const SolarIconsData suspensionBolt =
-      SolarIconsData(0xede9, fontFamily: _fontFamily);
-  static const SolarIconsData suspensionCross =
-      SolarIconsData(0xedea, fontFamily: _fontFamily);
-  static const SolarIconsData suspension =
-      SolarIconsData(0xedeb, fontFamily: _fontFamily);
-  static const SolarIconsData tram =
-      SolarIconsData(0xedec, fontFamily: _fontFamily);
-  static const SolarIconsData transmissionCircle =
-      SolarIconsData(0xeded, fontFamily: _fontFamily);
-  static const SolarIconsData transmissionSquare =
-      SolarIconsData(0xedee, fontFamily: _fontFamily);
-  static const SolarIconsData transmission =
-      SolarIconsData(0xedef, fontFamily: _fontFamily);
-  static const SolarIconsData wheelAngle =
-      SolarIconsData(0xedf0, fontFamily: _fontFamily);
-  static const SolarIconsData wheel =
-      SolarIconsData(0xedf1, fontFamily: _fontFamily);
-  static const SolarIconsData accumulator =
-      SolarIconsData(0xedf2, fontFamily: _fontFamily);
-  static const SolarIconsData shockAbsorber =
-      SolarIconsData(0xedf6, fontFamily: _fontFamily);
+  static const forward = IconData(0xe900, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const letterOpened = IconData(0xe901, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const letterUnread = IconData(0xe902, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const letter = IconData(0xe903, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const multipleForwardLeft = IconData(0xe904, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const multipleForwardRight = IconData(0xe905, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const paperclip2 = IconData(0xe906, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const paperclipRounded2 = IconData(0xe907, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const paperclipRounded = IconData(0xe908, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const paperclip = IconData(0xe909, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const pen2 = IconData(0xe90a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const penNewRound = IconData(0xe90b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const penNewSquare = IconData(0xe90c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const pen = IconData(0xe90d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const plain2 = IconData(0xe90e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const plain3 = IconData(0xe90f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const plain = IconData(0xe910, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareForward = IconData(0xe911, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareShareLine = IconData(0xe912, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chatDots = IconData(0xe913, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chatLine = IconData(0xe914, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chatRoundCall = IconData(0xe915, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chatRoundCheck = IconData(0xe916, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chatRoundLike = IconData(0xe917, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chatRoundUnread = IconData(0xe918, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chatRoundVideo = IconData(0xe919, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chatSquareArrow = IconData(0xe91a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chatSquareCall = IconData(0xe91b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chatSquareCheck = IconData(0xe91c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chatSquareCode = IconData(0xe91d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chatSquareLike = IconData(0xe91e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chatSquare = IconData(0xe91f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chatUnread = IconData(0xe920, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chatRead = IconData(0xe921, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const dialog2 = IconData(0xe922, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const inboxArchive = IconData(0xe923, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const inboxIn = IconData(0xe924, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const inboxLine = IconData(0xe925, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const inboxOut = IconData(0xe926, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const inboxUnread = IconData(0xe927, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const inbox = IconData(0xe928, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mailbox = IconData(0xe929, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const unread = IconData(0xe92a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chatRoundDots = IconData(0xe92b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chatRoundLine = IconData(0xe92f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chatRoundMoney = IconData(0xe930, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chatRound = IconData(0xe931, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const dialog = IconData(0xe932, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const altArrowLeft = IconData(0xe933, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const altArrowRight = IconData(0xe934, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const refreshCircle = IconData(0xe935, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const refreshSquare = IconData(0xe936, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const refresh = IconData(0xe937, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const restartCircle = IconData(0xe938, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const restartSquare = IconData(0xe939, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const restart = IconData(0xe93a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const altArrowDown = IconData(0xe93b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const altArrowUp = IconData(0xe93c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const arrowDown = IconData(0xe93d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const arrowLeftDown = IconData(0xe93e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const arrowLeftUp = IconData(0xe93f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const arrowLeft = IconData(0xe940, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const arrowRightDown = IconData(0xe941, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const arrowRightUp = IconData(0xe942, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const arrowRight = IconData(0xe943, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const arrowUp = IconData(0xe944, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const doubleAltArrowDown = IconData(0xe945, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const doubleAltArrowLeft = IconData(0xe946, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const doubleAltArrowRight = IconData(0xe947, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const doubleAltArrowUp = IconData(0xe948, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundAltArrowDown = IconData(0xe949, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundAltArrowUp = IconData(0xe94a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundArrowRightUp = IconData(0xe94b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundDoubleAltArrowLeft = IconData(0xe94c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundDoubleAltArrowRight = IconData(0xe94d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundDoubleAltArrowUp = IconData(0xe94e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundSortHorizontal = IconData(0xe94f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundTransferDiagonal = IconData(0xe950, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundTransferVertical = IconData(0xe951, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sortHorizontal = IconData(0xe952, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sortVertical = IconData(0xe953, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const transferHorizontal = IconData(0xe954, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const transferVertical = IconData(0xe955, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundAltArrowLeft = IconData(0xe956, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundAltArrowRight = IconData(0xe957, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundArrowDown = IconData(0xe958, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundArrowLeftDown = IconData(0xe959, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundArrowLeftUp = IconData(0xe95a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundArrowLeft = IconData(0xe95b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundArrowRightDown = IconData(0xe95c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundArrowRight = IconData(0xe95d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundArrowUp = IconData(0xe95e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundDoubleAltArrowDown = IconData(0xe95f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundSortVertical = IconData(0xe960, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundTransferHorizontal = IconData(0xe961, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareAltArrowDown = IconData(0xe962, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareArrowDown = IconData(0xe963, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareArrowLeftDown = IconData(0xe964, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareArrowLeftUp = IconData(0xe965, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareArrowLeft = IconData(0xe966, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareArrowRightDown = IconData(0xe967, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareArrowRightUp = IconData(0xe968, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareArrowRight = IconData(0xe969, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareArrowUp = IconData(0xe96a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareSortHorizontal = IconData(0xe96b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareSortVertical = IconData(0xe96c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareTransferHorizontal = IconData(0xe96d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareTransferVertical = IconData(0xe96e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareAltArrowLeft = IconData(0xe96f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareAltArrowRight = IconData(0xe970, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareAltArrowUp = IconData(0xe971, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareDoubleAltArrowRight = IconData(0xe972, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareDoubleAltArrowDown = IconData(0xe973, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareDoubleAltArrowLeft = IconData(0xe974, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareDoubleAltArrowUp = IconData(0xe975, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const branchingPathsDown = IconData(0xe976, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const branchingPathsUp = IconData(0xe977, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const compassBig = IconData(0xe978, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const globus = IconData(0xe979, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const gps = IconData(0xe97a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mapArrowLeft = IconData(0xe97b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mapArrowSquare = IconData(0xe97c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const pointOnMapPerspective = IconData(0xe97d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const radar2 = IconData(0xe97e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const radar = IconData(0xe97f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const route = IconData(0xe980, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const routing2 = IconData(0xe981, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const routing3 = IconData(0xe982, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const routing = IconData(0xe983, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const signpost2 = IconData(0xe984, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const signpost = IconData(0xe985, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const streetsMapPoint = IconData(0xe986, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const streetsNavigation = IconData(0xe987, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const streets = IconData(0xe988, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const compassSquare = IconData(0xe989, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const compass = IconData(0xe98a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const global = IconData(0xe98b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mapArrowDown = IconData(0xe98c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mapArrowRight = IconData(0xe98d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mapArrowUp = IconData(0xe98e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mapPointAdd = IconData(0xe98f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mapPointFavourite = IconData(0xe990, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mapPointHospital = IconData(0xe991, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mapPointRemove = IconData(0xe992, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mapPointRotate = IconData(0xe993, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mapPointSchool = IconData(0xe994, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mapPointSearch = IconData(0xe995, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mapPointWave = IconData(0xe996, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mapPoint = IconData(0xe997, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const map = IconData(0xe998, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const peopleNearby = IconData(0xe999, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const pointOnMap = IconData(0xe99a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cameraAdd = IconData(0xe99b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cameraMinimalistic = IconData(0xe99c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cameraRotate = IconData(0xe99d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cameraSquare = IconData(0xe99e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const camera = IconData(0xe99f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const fullScreenCircle = IconData(0xe9a0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const fullScreenSquare = IconData(0xe9a1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const fullScreen = IconData(0xe9a2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const galleryCircle = IconData(0xe9a3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const galleryRound = IconData(0xe9a4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const pip2 = IconData(0xe9a5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const pip = IconData(0xe9a6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const playbackSpeed = IconData(0xe9a7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const quitFullScreenCircle = IconData(0xe9a8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const quitFullScreenSquare = IconData(0xe9a9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const quitFullScreen = IconData(0xe9aa, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const quitPIP = IconData(0xe9ab, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const reel2 = IconData(0xe9ac, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const reel = IconData(0xe9ad, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const rewindBackCircle = IconData(0xe9ae, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const rewindForwardCircle = IconData(0xe9af, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const shuffle = IconData(0xe9b0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const stopCircle = IconData(0xe9b1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const stream = IconData(0xe9b2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const toPIP = IconData(0xe9b3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const videocameraAdd = IconData(0xe9b4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const videocameraRecord = IconData(0xe9b5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const videocamera = IconData(0xe9b6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const clapperboardEdit = IconData(0xe9b7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const clapperboardText = IconData(0xe9b8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const galleryCheck = IconData(0xe9b9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const galleryEdit = IconData(0xe9ba, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const galleryFavourite = IconData(0xe9bb, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const galleryRemove = IconData(0xe9bc, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const musicLibrary2 = IconData(0xe9bd, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const musicLibrary = IconData(0xe9be, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const musicNoteSlider2 = IconData(0xe9bf, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const musicNoteSlider = IconData(0xe9c0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const musicNotes = IconData(0xe9c1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const panorama = IconData(0xe9c2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const pauseCircle = IconData(0xe9c3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const playCircle = IconData(0xe9c4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const podcast = IconData(0xe9c5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const rewind10SecondsBack = IconData(0xe9c6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const rewind10SecondsForward = IconData(0xe9c7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const rewindBack = IconData(0xe9c8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const skipNext = IconData(0xe9c9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const skipPrevious = IconData(0xe9ca, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const uploadTrack2 = IconData(0xe9cb, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const uploadTrack = IconData(0xe9cc, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const videoFrame2 = IconData(0xe9cd, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const videoFramePlayHorizontal = IconData(0xe9ce, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const videoFramePlayVertical = IconData(0xe9cf, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const volumeCross = IconData(0xe9d0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const wallpaper = IconData(0xe9d1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const clapperboardOpenPlay = IconData(0xe9d2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const galleryAdd = IconData(0xe9d3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const galleryDownload = IconData(0xe9d4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const gallerySend = IconData(0xe9d5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const galleryWide = IconData(0xe9d6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const microphoneLarge = IconData(0xe9d7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const microphone = IconData(0xe9d8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const musicNote2 = IconData(0xe9d9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const musicNote = IconData(0xe9da, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const pause = IconData(0xe9db, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const playStream = IconData(0xe9dc, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const play = IconData(0xe9dd, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const repeatOneMinimalistic = IconData(0xe9de, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const rewind15SecondsBack = IconData(0xe9df, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const rewind15SecondsForward = IconData(0xe9e0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const rewindForward = IconData(0xe9e1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const soundwaveCircle = IconData(0xe9e2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const videoFrameCut2 = IconData(0xe9e3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const videoFrameReplace = IconData(0xe9e4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const videoLibrary = IconData(0xe9e5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const vinyl = IconData(0xe9e6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const volume = IconData(0xe9e7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const album = IconData(0xe9e8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const clapperboardOpen = IconData(0xe9e9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const clapperboardPlay = IconData(0xe9ea, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const galleryMinimalistic = IconData(0xe9eb, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const library = IconData(0xe9ec, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const microphone2 = IconData(0xe9ed, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const microphone3 = IconData(0xe9ee, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const musicNote3 = IconData(0xe9ef, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const muted = IconData(0xe9f0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const recordCircle = IconData(0xe9f1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const record = IconData(0xe9f2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const repeatOne = IconData(0xe9f3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const repeat = IconData(0xe9f4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const rewind5SecondsForward = IconData(0xe9f5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const soundwaveSquare = IconData(0xe9f6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const soundwave = IconData(0xe9f7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const stop = IconData(0xe9f8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const videoFrameCut = IconData(0xe9f9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const vinylRecord = IconData(0xe9fa, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const volumeLoud = IconData(0xe9fb, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const volumeSmall = IconData(0xe9fc, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const clapperboard = IconData(0xe9fd, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const gallery = IconData(0xe9fe, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const musicNote4 = IconData(0xe9ff, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const rewind5SecondsBack = IconData(0xea00, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const videoFrame = IconData(0xea01, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const billCheck = IconData(0xea02, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const billCross = IconData(0xea03, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const billList = IconData(0xea04, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bill = IconData(0xea05, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cashOut = IconData(0xea06, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const moneyBag = IconData(0xea07, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const safe2 = IconData(0xea08, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const banknote2 = IconData(0xea09, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const banknote = IconData(0xea0a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const card2 = IconData(0xea0b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cardReceive = IconData(0xea0c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cardSearch = IconData(0xea0d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cardSend = IconData(0xea0e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cardTransfer = IconData(0xea0f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const card = IconData(0xea10, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cardholder = IconData(0xea14, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const dollarMinimalistic = IconData(0xea15, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const dollar = IconData(0xea16, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const euro = IconData(0xea17, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const ruble = IconData(0xea18, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const safeCircle = IconData(0xea19, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const safeSquare = IconData(0xea1a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const saleSquare = IconData(0xea1b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sale = IconData(0xea1c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const tagHorizontal = IconData(0xea1d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const tagPrice = IconData(0xea1e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const tag = IconData(0xea1f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const tickerStar = IconData(0xea20, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const ticketSale = IconData(0xea21, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const ticket = IconData(0xea22, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const verifiedCheck = IconData(0xea23, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const wadOfMoney = IconData(0xea24, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const wallet2 = IconData(0xea25, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const walletMoney = IconData(0xea26, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const wallet = IconData(0xea27, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const headphonesRoundSound = IconData(0xea28, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const headphonesRound = IconData(0xea29, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const headphonesSquareSound = IconData(0xea2a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const headphonesSquare = IconData(0xea2b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mouseCircle = IconData(0xea2c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mouseMinimalistic = IconData(0xea2d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mouse = IconData(0xea2e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const server2 = IconData(0xea2f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const serverMinimalistic = IconData(0xea30, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const serverPath = IconData(0xea31, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const serverSquareCloud = IconData(0xea32, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const serverSquareUpdate = IconData(0xea33, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const serverSquare = IconData(0xea34, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const server = IconData(0xea35, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const smartphoneRotateAngle = IconData(0xea36, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const tablet = IconData(0xea37, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cloudStorage = IconData(0xea38, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const devices = IconData(0xea39, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const diskette = IconData(0xea3a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const flashDrive = IconData(0xea3b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const gamepadCharge = IconData(0xea3c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const gamepadMinimalistic = IconData(0xea3d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const gamepadNoCharge = IconData(0xea3e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const gamepadOld = IconData(0xea3f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const gamepad = IconData(0xea40, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const iPhone = IconData(0xea41, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const lightbulbBold = IconData(0xea42, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const lightbulbMinimalistic = IconData(0xea43, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const lightbulb = IconData(0xea44, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const lightning = IconData(0xea46, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const plugCircle = IconData(0xea47, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sdCard = IconData(0xea48, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const smartphone2 = IconData(0xea49, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const smartphoneRotate2 = IconData(0xea4a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const smartphoneRotateOrientation = IconData(0xea4b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const smartphoneUpdate = IconData(0xea4c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const smartphoneVibration = IconData(0xea4d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const smartphone = IconData(0xea4e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const socket = IconData(0xea4f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const ssdRound = IconData(0xea50, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const ssdSquare = IconData(0xea51, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const weigher = IconData(0xea52, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const wirelessCharge = IconData(0xea53, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bluetoothCircle = IconData(0xea54, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bluetoothSquare = IconData(0xea55, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bluetoothWave = IconData(0xea56, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bluetooth = IconData(0xea57, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cassette2 = IconData(0xea58, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cassette = IconData(0xea59, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const display = IconData(0xea5a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const gameboy = IconData(0xea5b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const keyboard = IconData(0xea5c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const monitorCamera = IconData(0xea5d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const monitorSmartphone = IconData(0xea5e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const monitor = IconData(0xea5f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const printer2 = IconData(0xea60, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const printerMinimalistic = IconData(0xea61, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const printer = IconData(0xea62, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const projector = IconData(0xea63, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const radioMinimalistic = IconData(0xea64, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const radio = IconData(0xea65, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const simCardMinimalistic = IconData(0xea66, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const simCard = IconData(0xea67, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const simCards = IconData(0xea68, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const smartSpeaker2 = IconData(0xea69, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const smartSpeakerMinimalistic = IconData(0xea6a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const smartSpeaker = IconData(0xea6b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const telescope = IconData(0xea6c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const tv = IconData(0xea6d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const airbudsCaseCharge = IconData(0xea6e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const airbudsCaseMinimalistic = IconData(0xea6f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const airbudsCaseOpen = IconData(0xea70, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const airbudsCase = IconData(0xea71, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const airbudsCharge = IconData(0xea72, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const airbudsCheck = IconData(0xea73, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const airbudsLeft = IconData(0xea74, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const airbudsRemove = IconData(0xea75, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const airbudsRight = IconData(0xea76, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const airbuds = IconData(0xea77, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const boombox = IconData(0xea78, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cpuBolt = IconData(0xea79, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cpu = IconData(0xea7a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const laptop2 = IconData(0xea7b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const laptop3 = IconData(0xea7c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const laptopMinimalistic = IconData(0xea7d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const laptop = IconData(0xea7e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const turntableMinimalistic = IconData(0xea7f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const turntableMusicNote = IconData(0xea80, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const turntable = IconData(0xea81, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const moonFog = IconData(0xea82, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const snowflake = IconData(0xea83, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sunfog = IconData(0xea84, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sunrise = IconData(0xea85, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sunset = IconData(0xea86, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const temperature = IconData(0xea87, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const tornadoSmall = IconData(0xea88, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const waterdrops = IconData(0xea89, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const wind = IconData(0xea8a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cloudBoltMinimalistic = IconData(0xea8b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cloudDownload = IconData(0xea8c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cloudRain = IconData(0xea8d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cloudSnowfallMinimalistic = IconData(0xea8e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cloudSnowfall = IconData(0xea8f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cloudStorm = IconData(0xea90, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cloudSun2 = IconData(0xea91, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cloudUpload = IconData(0xea92, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cloudWaterdrop = IconData(0xea93, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cloudWaterdrops = IconData(0xea94, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cloudyMoon = IconData(0xea95, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const fog = IconData(0xea96, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const moonSleep = IconData(0xea97, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const moonStars = IconData(0xea98, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const moon = IconData(0xea99, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const stars = IconData(0xea9a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sun2 = IconData(0xea9b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sun = IconData(0xea9c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const tornado = IconData(0xea9d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cloudBolt = IconData(0xea9e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cloudCheck = IconData(0xea9f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cloudMinus = IconData(0xeaa0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cloudPlus = IconData(0xeaa1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cloudSun = IconData(0xeaa2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cloud = IconData(0xeaa3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const clouds = IconData(0xeaa4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cloudCross = IconData(0xeaa5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cloudFile = IconData(0xeaa6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const codeFile = IconData(0xeaa7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const figmaFile = IconData(0xeaa8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const fileCheck = IconData(0xeaa9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const fileCorrupted = IconData(0xeaaa, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const fileDownload = IconData(0xeaab, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const fileFavourite = IconData(0xeaac, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const fileLeft = IconData(0xeaad, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const fileRemove = IconData(0xeaae, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const fileRight = IconData(0xeaaf, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const fileSend = IconData(0xeab0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const fileSmile = IconData(0xeab1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const fileText = IconData(0xeab2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const file = IconData(0xeab3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const zipFile = IconData(0xeab4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const addFolder = IconData(0xeab5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const folder2 = IconData(0xeab6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const folderCheck = IconData(0xeab7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const folderCloud = IconData(0xeab8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const folderError = IconData(0xeab9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const folderFavouriteBookmark = IconData(0xeaba, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const folderFavouriteStar = IconData(0xeabb, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const folderOpen = IconData(0xeabc, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const folderPathConnect = IconData(0xeabd, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const folderSecurity = IconData(0xeabe, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const folderWithFiles = IconData(0xeabf, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const folder = IconData(0xeac2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const moveToFolder = IconData(0xeac3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const removeFolder = IconData(0xeac4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const starFall2 = IconData(0xeac5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const starRing = IconData(0xeac6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const starRings = IconData(0xeac7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const ufo2 = IconData(0xeac8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const ufo3 = IconData(0xeac9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const ufo = IconData(0xeaca, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const asteroid = IconData(0xeacb, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const atom = IconData(0xeacc, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const blackHole2 = IconData(0xeacd, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const blackHole3 = IconData(0xeace, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const earth = IconData(0xeacf, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const infinity = IconData(0xead0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const men = IconData(0xead1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const planet2 = IconData(0xead2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const planet3 = IconData(0xead3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const planet4 = IconData(0xead4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const planet = IconData(0xead5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const rocket2 = IconData(0xead6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const rocket = IconData(0xead7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const satellite = IconData(0xead8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const starAngle = IconData(0xead9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const starCircle = IconData(0xeada, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const starFallMinimalistic2 = IconData(0xeadb, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const starFallMinimalistic = IconData(0xeadc, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const starFall = IconData(0xeadd, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const starRainbow = IconData(0xeade, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const star = IconData(0xeadf, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const starsLine = IconData(0xeae0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const starsMinimalistic = IconData(0xeae1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const stars1 = IconData(0xeae2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const women = IconData(0xeae3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const blackHole = IconData(0xeae4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const confoundedCircle = IconData(0xeae5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const confoundedSquare = IconData(0xeae6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const emojiFunnyCircle = IconData(0xeae7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const emojiFunnySquare = IconData(0xeae8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const facemaskCircle = IconData(0xeae9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const facemaskSquare = IconData(0xeaea, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sleepingCircle = IconData(0xeaeb, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sleepingSquare = IconData(0xeaec, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const stickerCircle = IconData(0xeaed, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const stickerSmileCircle2 = IconData(0xeaee, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const stickerSmileCircle = IconData(0xeaef, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const stickerSmileSquare = IconData(0xeaf0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const stickerSquare = IconData(0xeaf1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const expressionlessCircle = IconData(0xeaf2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const expressionlessSquare = IconData(0xeaf3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const faceScanCircle = IconData(0xeaf4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const faceScanSquare = IconData(0xeaf5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sadCircle = IconData(0xeaf6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sadSquare = IconData(0xeaf7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const smileCircle = IconData(0xeaf8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const smileSquare = IconData(0xeaf9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const balls = IconData(0xeafa, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const basketball = IconData(0xeafb, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bodyShapeMinimalistic = IconData(0xeafc, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bodyShape = IconData(0xeafd, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bowling = IconData(0xeafe, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const dumbbellLargeMinimalistic = IconData(0xeaff, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const dumbbellLarge = IconData(0xeb00, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const dumbbellSmall = IconData(0xeb01, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const dumbbell = IconData(0xeb02, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const dumbbells2 = IconData(0xeb03, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const dumbbells = IconData(0xeb04, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const football = IconData(0xeb05, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const golf = IconData(0xeb06, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const meditationRound = IconData(0xeb07, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const meditation = IconData(0xeb08, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const ranking = IconData(0xeb09, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const rugby = IconData(0xeb0a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const stretchingRound = IconData(0xeb0b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const stretching = IconData(0xeb0c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const swimming = IconData(0xeb0d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const tennis2 = IconData(0xeb0e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const tennis = IconData(0xeb0f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const treadmillRound = IconData(0xeb10, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const treadmill = IconData(0xeb11, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const volleyball2 = IconData(0xeb12, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const volleyball = IconData(0xeb13, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const waterSun = IconData(0xeb14, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const water = IconData(0xeb15, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bicyclingRound = IconData(0xeb16, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bicycling = IconData(0xeb17, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const hikingMinimalistic = IconData(0xeb18, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const hikingRound = IconData(0xeb19, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const hiking = IconData(0xeb1a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const running_2 = IconData(0xeb1b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const runningRound = IconData(0xeb1c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const running = IconData(0xeb1d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const skateboard = IconData(0xeb1e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const skateboardingRound = IconData(0xeb1f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const skateboarding = IconData(0xeb20, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const walkingRound = IconData(0xeb21, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const walking = IconData(0xeb22, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const magnifierBug = IconData(0xeb23, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const magnifierZoomIn = IconData(0xeb24, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const magnifierZoomOut = IconData(0xeb25, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const magnifier = IconData(0xeb26, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const minimalisticMagnifierBug = IconData(0xeb27, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const minimalisticMagnifierZoomIn = IconData(0xeb28, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const minimalisticMagnifierZoomOut = IconData(0xeb2b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const minimalisticMagnifier = IconData(0xeb2e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundedMagnifierBug = IconData(0xeb2f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundedMagnifierZoomIn = IconData(0xeb30, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundedMagnifierZoomOut = IconData(0xeb33, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundedMagnifier = IconData(0xeb36, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const calendarAdd = IconData(0xeb37, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const calendarDate = IconData(0xeb38, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const calendarMark = IconData(0xeb39, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const calendarMinimalistic = IconData(0xeb3a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const calendarSearch = IconData(0xeb3b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const calendar = IconData(0xeb3c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const history3 = IconData(0xeb3d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const hourglassLine = IconData(0xeb3e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const hourglass = IconData(0xeb3f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const watchRound = IconData(0xeb40, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const watchSquareMinimalisticCharge = IconData(0xeb41, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const watchSquareMinimalistic = IconData(0xeb42, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const watchSquare = IconData(0xeb43, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const alarmAdd = IconData(0xeb47, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const alarmPause = IconData(0xeb48, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const alarmPlay = IconData(0xeb49, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const alarmRemove = IconData(0xeb4a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const alarmSleep = IconData(0xeb4b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const alarmTurnOff = IconData(0xeb4c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const alarm = IconData(0xeb4d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const clockCircle = IconData(0xeb4e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const clockSquare = IconData(0xeb50, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const history_2 = IconData(0xeb52, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const history = IconData(0xeb53, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const stopwatchPause = IconData(0xeb54, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const stopwatchPlay = IconData(0xeb55, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const stopwatch = IconData(0xeb56, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bill1 = IconData(0xeb57, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const checklistMinimalistic = IconData(0xeb58, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const checklist = IconData(0xeb59, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const listArrowDownMinimalistic = IconData(0xeb5a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const listArrowDown = IconData(0xeb5b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const listArrowUpMinimalistic = IconData(0xeb5c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const listArrowUp = IconData(0xeb5d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const listUpMinimalistic = IconData(0xeb5e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const listUp = IconData(0xeb5f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const list_1 = IconData(0xeb60, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const playlist = IconData(0xeb61, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sortByAlphabet = IconData(0xeb62, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sortByTime = IconData(0xeb63, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const listCheckMinimalistic = IconData(0xeb64, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const listCheck = IconData(0xeb65, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const listCrossMinimalistic = IconData(0xeb66, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const listCross = IconData(0xeb67, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const listDownMinimalistic = IconData(0xeb68, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const listDown = IconData(0xeb69, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const listHeartMinimalistic = IconData(0xeb6a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const listHeart = IconData(0xeb6b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const list = IconData(0xeb6c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const playlistMinimalistic = IconData(0xeb6d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const playlist_2 = IconData(0xeb6e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const playlistMinimalistic2 = IconData(0xeb6f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const playlistMinimalistic3 = IconData(0xeb70, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sortFromBottomToTop = IconData(0xeb71, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sortFromTopToBottom = IconData(0xeb72, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const callChat = IconData(0xeb73, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const callDropped = IconData(0xeb74, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const callMedicine = IconData(0xeb75, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const incomingCall = IconData(0xeb76, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const outgoingCall = IconData(0xeb77, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const recordCircle1 = IconData(0xeb78, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const recordMinimalistic = IconData(0xeb79, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const recordSquare = IconData(0xeb7a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const callCancelRounded = IconData(0xeb7b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const callCancel = IconData(0xeb7c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const callChatRounded = IconData(0xeb7d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const callDroppedRounded = IconData(0xeb7e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const callMedicineRounded = IconData(0xeb7f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const endCallRounded = IconData(0xeb80, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const endCall = IconData(0xeb81, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const incomingCallRounded = IconData(0xeb82, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const outgoingCallRounded = IconData(0xeb83, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const phoneCallingRounded = IconData(0xeb84, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const phoneCalling = IconData(0xeb85, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const phoneRounded = IconData(0xeb86, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const phone = IconData(0xeb87, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const boneBroken = IconData(0xeb88, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const boneCrack = IconData(0xeb89, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bone = IconData(0xeb8a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bones = IconData(0xeb8b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const health = IconData(0xeb8c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const heartPulse2 = IconData(0xeb8d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const heartPulse = IconData(0xeb8e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const medicalKit = IconData(0xeb8f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const pills = IconData(0xeb90, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const pulse_2 = IconData(0xeb91, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const pulse = IconData(0xeb92, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const testTubeMinimalistic = IconData(0xeb93, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const testTube = IconData(0xeb94, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const virus = IconData(0xeb95, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const adhesivePlaster2 = IconData(0xeb96, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const adhesivePlaster = IconData(0xeb97, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bacteria = IconData(0xeb98, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const benzeneRing = IconData(0xeb99, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const dna = IconData(0xeb9a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const dropper_2 = IconData(0xeb9b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const dropper_3 = IconData(0xeb9c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const dropperMinimalistic2 = IconData(0xeb9d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const dropperMinimalistic = IconData(0xeb9e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const dropper = IconData(0xeb9f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const jarOfPills2 = IconData(0xeba0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const jarOfPills = IconData(0xeba1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const pill = IconData(0xeba2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const pills_2 = IconData(0xeba3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const pills_3 = IconData(0xeba4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const stethoscope = IconData(0xeba5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const syringe = IconData(0xeba6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const thermometer = IconData(0xeba7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const armchair_2 = IconData(0xeba8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const armchair = IconData(0xeba9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const barChair = IconData(0xebaa, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bath = IconData(0xebab, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bed = IconData(0xebac, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bedsideTable2 = IconData(0xebad, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bedsideTable3 = IconData(0xebae, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bedsideTable4 = IconData(0xebaf, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bedsideTable = IconData(0xebb0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chair_2 = IconData(0xebb1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chair = IconData(0xebb2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chandelier = IconData(0xebb3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const closet_2 = IconData(0xebb4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const closet = IconData(0xebb5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const floorLampMinimalistic = IconData(0xebb6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const floorLamp = IconData(0xebb7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const fridge = IconData(0xebb8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const lamp = IconData(0xebb9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mirror = IconData(0xebba, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const smartVacuumCleaner_2 = IconData(0xebbb, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const smartVacuumCleaner = IconData(0xebbc, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sofa_2 = IconData(0xebbd, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sofa_3 = IconData(0xebbe, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const trellis = IconData(0xebbf, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const volumeKnob = IconData(0xebc0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const conditioner_2 = IconData(0xebc1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const conditioner = IconData(0xebc2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const remoteController2 = IconData(0xebc3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const remoteControllerMinimalistic = IconData(0xebc4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const remoteController = IconData(0xebc5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sofa = IconData(0xebc6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const speakerMinimalistic = IconData(0xebc7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const speaker = IconData(0xebc8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const washingMachineMinimalistic = IconData(0xebc9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const washingMachine = IconData(0xebca, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const settingsMinimalistic = IconData(0xebcb, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const settings = IconData(0xebcc, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const tuning_2 = IconData(0xebcd, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const tuning_3 = IconData(0xebce, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const tuning_4 = IconData(0xebcf, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const tuningSquare_2 = IconData(0xebd0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const tuningSquare = IconData(0xebd1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const tuning = IconData(0xebd2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const widget_2 = IconData(0xebd3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const widget_3 = IconData(0xebd4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const widget_4 = IconData(0xebd5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const widget_5 = IconData(0xebd6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const widget_6 = IconData(0xebd7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const widgetAdd = IconData(0xebd8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const widget = IconData(0xebd9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const hashtagChat = IconData(0xebda, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const hashtagCircle = IconData(0xebdb, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bugMinimalistic = IconData(0xebdc, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bug = IconData(0xebdd, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const code2 = IconData(0xebde, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const codeCircle = IconData(0xebdf, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const codeSquare = IconData(0xebe0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const code = IconData(0xebe1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const command = IconData(0xebe2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const hashtagSquare = IconData(0xebe3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const hashtag = IconData(0xebe4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const programming = IconData(0xebe5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const screencast_2 = IconData(0xebe6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const screencast = IconData(0xebe7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sidebarCode = IconData(0xebe8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sidebarMinimalistic = IconData(0xebe9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sidebar = IconData(0xebea, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const slashCircle = IconData(0xebeb, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const slashSquare = IconData(0xebec, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const stationMinimalistic = IconData(0xebed, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const station = IconData(0xebee, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const structure = IconData(0xebef, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const translation_2 = IconData(0xebf0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const translation = IconData(0xebf1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const usbCircle = IconData(0xebf2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const usbSquare = IconData(0xebf3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const usb = IconData(0xebf4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const windowFrame = IconData(0xebf5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const wifiRouterMinimalistic = IconData(0xebf6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const wifiRouterRound = IconData(0xebf7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const wifiRouter = IconData(0xebf8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const backspace = IconData(0xebf9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const linkBrokenMinimalistic = IconData(0xebfa, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const linkBroken = IconData(0xebfb, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const linkCircle = IconData(0xebfc, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const linkMinimalistic_2 = IconData(0xebfd, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const linkMinimalistic = IconData(0xebfe, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const linkRoundAngle = IconData(0xebff, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const linkRound = IconData(0xec00, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const linkSquare = IconData(0xec01, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const link = IconData(0xec02, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const paragraphSpacing = IconData(0xec03, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const textBoldCircle = IconData(0xec04, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const textBoldSquare = IconData(0xec05, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const textBold = IconData(0xec06, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const textCrossCircle = IconData(0xec07, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const textCrossSquare = IconData(0xec08, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const textCross = IconData(0xec09, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const textFieldFocus = IconData(0xec0a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const textField = IconData(0xec0b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const textSelection = IconData(0xec0c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const textSquare2 = IconData(0xec0d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const textSquare = IconData(0xec0e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const textUnderlineCircle = IconData(0xec0f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const textUnderlineCross = IconData(0xec10, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const textUnderline = IconData(0xec11, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const text = IconData(0xec12, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const eraserCircle = IconData(0xec13, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const eraserSquare = IconData(0xec14, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const eraser = IconData(0xec15, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const textCircle = IconData(0xec16, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const textItalicCircle = IconData(0xec17, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const textItalicSquare = IconData(0xec18, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const textItalic = IconData(0xec19, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chart_2 = IconData(0xec1a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chartSquare = IconData(0xec1b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chart = IconData(0xec1c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chatSquare_2 = IconData(0xec1d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const courseDown = IconData(0xec1e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const courseUp = IconData(0xec1f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const diagramDown = IconData(0xec20, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const diagramUp = IconData(0xec21, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const graphDownNew = IconData(0xec22, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const graphDown = IconData(0xec23, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const graphNewUp = IconData(0xec24, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const graphNew = IconData(0xec25, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const graphUp = IconData(0xec26, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const graph = IconData(0xec27, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const pieChart3 = IconData(0xec28, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const presentationGraph = IconData(0xec29, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundGraph = IconData(0xec2a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const pieChart2 = IconData(0xec2b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const pieChart = IconData(0xec2c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bag2 = IconData(0xec2d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bag3 = IconData(0xec2e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bag4 = IconData(0xec2f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bag5 = IconData(0xec30, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bagCheck = IconData(0xec31, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bagCross = IconData(0xec32, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bagHeart = IconData(0xec33, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bagMusic_2 = IconData(0xec34, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bagMusic = IconData(0xec35, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bagSmile = IconData(0xec36, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bag = IconData(0xec37, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cart_2 = IconData(0xec38, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cart_3 = IconData(0xec39, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cart_4 = IconData(0xec3a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cart_5 = IconData(0xec3b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cart = IconData(0xec3c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const shop_2 = IconData(0xec3d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const shopMinimalistic = IconData(0xec3e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const shop = IconData(0xec3f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cartCheck = IconData(0xec40, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cartCross = IconData(0xec41, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cartLarge2 = IconData(0xec42, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cartLarge3 = IconData(0xec43, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cartLarge_4 = IconData(0xec44, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cartLargeMinimalistic = IconData(0xec45, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cartLarge = IconData(0xec46, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cartPlus = IconData(0xec47, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const suitcaseLines = IconData(0xec48, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const suitcaseTag = IconData(0xec49, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bonfire = IconData(0xec4a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const fireMinimalistic = IconData(0xec4b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const fireSquare = IconData(0xec4c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const fire = IconData(0xec4d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const flame = IconData(0xec4e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const leaf = IconData(0xec4f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const suitcase = IconData(0xec50, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const backpack = IconData(0xec51, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const caseRound = IconData(0xec52, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const case_ = IconData(0xec53, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareAcademicCap2 = IconData(0xec54, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareAcademicCap = IconData(0xec55, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const book2 = IconData(0xec56, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bookBookmarkMinimalistic = IconData(0xec57, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bookBookmark = IconData(0xec58, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bookMinimalistic = IconData(0xec59, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const book = IconData(0xec5a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bookmarkCircle = IconData(0xec5b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bookmarkOpened = IconData(0xec5c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bookmarkSquareMinimalistic = IconData(0xec5d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bookmarkSquare = IconData(0xec5e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bookmark = IconData(0xec5f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const calculatorMinimalistic = IconData(0xec60, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const calculator = IconData(0xec61, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const caseMinimalistic = IconData(0xec62, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const caseRoundMinimalistic = IconData(0xec63, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const diplomaVerified = IconData(0xec64, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const diploma = IconData(0xec65, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const document = IconData(0xec66, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const notebookBookmark = IconData(0xec67, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const notebookMinimalistic = IconData(0xec68, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const notebookSquare = IconData(0xec69, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const notebook = IconData(0xec6a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const passportMinimalistic = IconData(0xec6b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const passport = IconData(0xec6c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const plus = IconData(0xec6d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const minus = IconData(0xec6d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const ovenMittsMinimalistic = IconData(0xec6e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bottle = IconData(0xec6f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chefHatHeart = IconData(0xec70, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chefHatMinimalistic = IconData(0xec71, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chefHat = IconData(0xec72, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const corkscrew = IconData(0xec73, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cupHot = IconData(0xec74, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cupPaper = IconData(0xec75, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cup = IconData(0xec76, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const donutBitten = IconData(0xec77, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const donut = IconData(0xec78, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const ladle = IconData(0xec79, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const ovenMitts = IconData(0xec7a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const rollingPin = IconData(0xec7b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const teaCup = IconData(0xec7c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const whisk = IconData(0xec7d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const wineglassTriangle = IconData(0xec7e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const wineglass = IconData(0xec7f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const alignBottom = IconData(0xec80, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const alignHorizontalSpacing = IconData(0xec81, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const alignHorizontalCenter = IconData(0xec82, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const alignLeft = IconData(0xec83, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const alignRight = IconData(0xec84, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const alignTop = IconData(0xec85, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const alignVerticalCenter = IconData(0xec86, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const alignVerticalSpacing = IconData(0xec87, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const paintRoller = IconData(0xec88, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const colourTuning = IconData(0xec89, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cropMinimalistic = IconData(0xec8a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const crop = IconData(0xec8b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const filters = IconData(0xec8c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const flipHorizontal = IconData(0xec8d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const flipVertical = IconData(0xec8e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const layersMinimalistic = IconData(0xec8f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const layers = IconData(0xec90, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mirrorLeft = IconData(0xec91, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mirrorRight = IconData(0xec92, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const paletteRound = IconData(0xec93, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const palette = IconData(0xec94, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const palette2 = IconData(0xec95, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const pipette = IconData(0xec96, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const radialBlur = IconData(0xec97, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const rulerAngular = IconData(0xec98, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const rulerCrossPen = IconData(0xec99, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const rulerPen = IconData(0xec9a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const ruler = IconData(0xec9b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const threeSquares = IconData(0xec9c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const dislike = IconData(0xec9d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const heartAngle = IconData(0xec9e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const heartBroken = IconData(0xec9f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const heartLock = IconData(0xeca0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const heartShine = IconData(0xeca1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const heartUnlock = IconData(0xeca2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const heart = IconData(0xeca3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const hearts = IconData(0xeca4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const like = IconData(0xeca5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const medalRibbonStar = IconData(0xeca6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const medalRibbon = IconData(0xeca7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const medalRibbonsStart = IconData(0xeca8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const medalStarCircle = IconData(0xeca9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const medalStarSquare = IconData(0xecaa, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const medalStar = IconData(0xecab, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const startShine = IconData(0xecac, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const start1 = IconData(0xecad, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const archiveCheck = IconData(0xecae, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const archiveDownMinimalistic = IconData(0xecaf, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const archiveDown = IconData(0xecb0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const archiveMinimalistic = IconData(0xecb1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const archiveUpMinimalistic = IconData(0xecb2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const archiveUp = IconData(0xecb3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const archive = IconData(0xecb4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const clipboardAdd = IconData(0xecb5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const clipboardCheck = IconData(0xecb6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const clipboardHeart = IconData(0xecb7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const clipboardList = IconData(0xecb8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const clipboardRemove = IconData(0xecb9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const clipboardText = IconData(0xecba, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const clipboard = IconData(0xecbb, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const documentAdd = IconData(0xecbc, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const documentMedicine = IconData(0xecbd, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const documentText = IconData(0xecbe, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const document1 = IconData(0xecbf, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const documentsMinimalistic = IconData(0xecc0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const documents = IconData(0xecc1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const notebook1 = IconData(0xecc2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const notesMinimalistic = IconData(0xecc3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const notes = IconData(0xecc4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const arrowToDownRight = IconData(0xecc5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const arrowToTopLeft = IconData(0xecc6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const arrowToTopRight = IconData(0xecc7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const arrowToDownLeft = IconData(0xecc8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const downloadMinimalistic = IconData(0xecc9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const download = IconData(0xecca, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const exit = IconData(0xeccb, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const export = IconData(0xeccc, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const forward_2 = IconData(0xeccd, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const forward1 = IconData(0xecce, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const import = IconData(0xeccf, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const login_2 = IconData(0xecd0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const login_3 = IconData(0xecd1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const login = IconData(0xecd2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const logout_2 = IconData(0xecd3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const logout_3 = IconData(0xecd4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const logout = IconData(0xecd5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const maximizeSquare2 = IconData(0xecd6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const minimizeSquare2 = IconData(0xecd7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const minimizeSquareMinimalistic = IconData(0xecd8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const reply_2 = IconData(0xecd9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const reply = IconData(0xecda, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const screenShare = IconData(0xecdb, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const uploadMinimalistic = IconData(0xecdc, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const upload = IconData(0xecdd, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const circleBottomDown = IconData(0xecde, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const circleBottomUp = IconData(0xecdf, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const circleTopDown = IconData(0xece0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const circleTopUp = IconData(0xece1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const maximizeSquare3 = IconData(0xece2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const maximizeSquareMinimalistic = IconData(0xece3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const maximizeSquare = IconData(0xece4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const maximize = IconData(0xece5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const minimizeSquare3 = IconData(0xece6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const minimizeSquare = IconData(0xece7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const minimize = IconData(0xece8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const reorder = IconData(0xece9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const scale = IconData(0xecea, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareBottomDown = IconData(0xeceb, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareBottomUp = IconData(0xecec, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareTopDown = IconData(0xeced, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareTopUp = IconData(0xecee, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const undoLeftRoundSquare = IconData(0xecef, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const undoLeftRound = IconData(0xecf0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const undoLeftSquare = IconData(0xecf1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const undoLeft = IconData(0xecf2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const undoRightRoundSquare = IconData(0xecf3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const undoRightRound = IconData(0xecf4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const undoRightSquare = IconData(0xecf5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const undoRight = IconData(0xecf6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const downloadSquare = IconData(0xecf7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const downloadTwiceSquare = IconData(0xecf8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const receiveSquare = IconData(0xecf9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const receiveTwiceSquare = IconData(0xecfa, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sendSquare = IconData(0xecfb, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sendTwiceSquare = IconData(0xecfc, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const uploadSquare = IconData(0xecfd, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const uploadTwiceSquare = IconData(0xecfe, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bellBing = IconData(0xecff, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bellOff = IconData(0xed00, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bell = IconData(0xed01, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const notificationLinesRemove = IconData(0xed02, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const notificationRemove = IconData(0xed03, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const notificationUnreadLines = IconData(0xed04, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const notificationUnread = IconData(0xed05, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const codeScan = IconData(0xed06, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const eyeScan = IconData(0xed07, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const incognito = IconData(0xed08, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const keyMinimalistic2 = IconData(0xed09, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const keyMinimalisticSquare_2 = IconData(0xed0a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const keyMinimalisticSquare_3 = IconData(0xed0b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const keyMinimalisticSquare = IconData(0xed0c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const keyMinimalistic = IconData(0xed0d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const objectScan = IconData(0xed0e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const qrCode = IconData(0xed0f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const scanner_2 = IconData(0xed10, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const scanner = IconData(0xed11, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const shieldCheck = IconData(0xed12, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const shieldCross = IconData(0xed13, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const shieldKeyholeMinimalistic = IconData(0xed14, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const shieldKeyhole = IconData(0xed15, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const shieldMinimalistic = IconData(0xed16, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const shieldMinus = IconData(0xed17, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const shieldNetwork = IconData(0xed18, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const shieldPlus = IconData(0xed19, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const shieldStar = IconData(0xed1a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const shieldUp = IconData(0xed1b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const shieldUser = IconData(0xed1c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const shieldWarning = IconData(0xed1d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const shield = IconData(0xed1e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bombEmoji = IconData(0xed1f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bombMinimalistic = IconData(0xed20, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bomb = IconData(0xed21, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const eyeClosed = IconData(0xed22, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const eye = IconData(0xed23, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const keySquare_2 = IconData(0xed24, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const keySquare = IconData(0xed25, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const key = IconData(0xed26, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const lockKeyholeMinimalisticUnlocked = IconData(0xed27, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const lockKeyholeMinimalistic = IconData(0xed28, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const lockKeyholeUnlocked = IconData(0xed29, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const lockKeyhole = IconData(0xed2a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const lockPassword_ = IconData(0xed2b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const lockPassword = IconData(0xed2c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const lockUnlocked = IconData(0xed2d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const lock = IconData(0xed2e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const passwordMinimalisticInput = IconData(0xed2f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const passwordMinimalistic = IconData(0xed30, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const password = IconData(0xed31, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sirenRounded = IconData(0xed32, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const siren = IconData(0xed33, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const userBlockRounded = IconData(0xed34, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const userBlock = IconData(0xed35, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const userCheck = IconData(0xed36, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const userCircle = IconData(0xed37, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const userCrossRounded = IconData(0xed38, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const userCross = IconData(0xed39, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const userHandUp = IconData(0xed3a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const userHands = IconData(0xed3b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const userHeartRounded = IconData(0xed3c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const userHeart = IconData(0xed3d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const userId = IconData(0xed3e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const userMinusRounded = IconData(0xed3f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const userMinus = IconData(0xed40, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const userPlusRounded = IconData(0xed41, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const userPlus = IconData(0xed42, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const userSpeakRounded = IconData(0xed43, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const userSpeak = IconData(0xed44, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const user = IconData(0xed45, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const userCheckRounded = IconData(0xed46, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const userRounded = IconData(0xed47, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const usersGroupRounded = IconData(0xed48, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const usersGroupTwoRounded = IconData(0xed49, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const handHeart = IconData(0xed4a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const handMoney = IconData(0xed4b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const handPills = IconData(0xed4c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const handShake = IconData(0xed4d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const handStars = IconData(0xed4e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const accessibility = IconData(0xed4f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const body = IconData(0xed50, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const hanger_2 = IconData(0xed51, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const hanger = IconData(0xed52, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const maskHapply = IconData(0xed53, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const maskSad = IconData(0xed54, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const masks = IconData(0xed55, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mentionCircle = IconData(0xed56, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mentionSquare = IconData(0xed57, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const skirt = IconData(0xed58, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const tShirt = IconData(0xed59, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const boxMinimalistic = IconData(0xed5a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const box = IconData(0xed5b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const confettiMinimalistic = IconData(0xed5c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const confetti = IconData(0xed5d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cosmetic = IconData(0xed5e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cursorSquare = IconData(0xed5f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cursor = IconData(0xed60, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const delivery = IconData(0xed61, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const feed = IconData(0xed62, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const ferrisWheel = IconData(0xed63, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const flashlightOn = IconData(0xed64, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const flashlight = IconData(0xed65, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const gift = IconData(0xed66, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const glasses = IconData(0xed67, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const magicStick_2 = IconData(0xed68, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const magicStick_3 = IconData(0xed69, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const magicStick = IconData(0xed6a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const magnetWave = IconData(0xed6b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const magnet = IconData(0xed6c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mirror1 = IconData(0xed6d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const perfume = IconData(0xed6e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const scissorsSquare = IconData(0xed6f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const scissors = IconData(0xed70, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sledgehammer = IconData(0xed71, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sleeping = IconData(0xed72, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const k = IconData(0xed73, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const augmentedReality = IconData(0xed74, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const balloon = IconData(0xed75, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const copyright = IconData(0xed76, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const creativeCommons = IconData(0xed77, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cupFirst = IconData(0xed78, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cupMusic = IconData(0xed79, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cupStar = IconData(0xed7a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cup1 = IconData(0xed7b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const explicit = IconData(0xed7c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const filter = IconData(0xed7d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const flag_2 = IconData(0xed7e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const flag = IconData(0xed7f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const hamburgerMenu = IconData(0xed80, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const highDefinition = IconData(0xed81, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const highQuality = IconData(0xed82, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const paperBin = IconData(0xed83, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const paw = IconData(0xed84, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const reorder1 = IconData(0xed85, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sort = IconData(0xed86, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const specialEffects = IconData(0xed87, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const xxx = IconData(0xed88, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const boltCircle = IconData(0xed89, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bolt = IconData(0xed8a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const broom = IconData(0xed8b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cat = IconData(0xed8c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const copy = IconData(0xed8d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const figma = IconData(0xed8e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const fuel = IconData(0xed8f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const ghostSmile = IconData(0xed90, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const ghost = IconData(0xed91, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const help = IconData(0xed92, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const plate = IconData(0xed93, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const postsCarouselHorizontal = IconData(0xed94, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const postsCarouselVertical = IconData(0xed95, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const power = IconData(0xed96, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const shareCircle = IconData(0xed97, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const share = IconData(0xed98, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const subtitles = IconData(0xed99, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const target = IconData(0xed9a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const trashBin2 = IconData(0xed9b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const trashBinMinimalistic_2 = IconData(0xed9c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const umbrella = IconData(0xed9d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const waterdrop = IconData(0xed9e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const winRar = IconData(0xed9f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const batteryChargeMinimalistic = IconData(0xeda0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const batteryCharge = IconData(0xeda1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const batteryFullMinimalistic = IconData(0xeda2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const batteryFull = IconData(0xeda3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const batteryHalfMinimalistic = IconData(0xeda4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const batteryHalf = IconData(0xeda5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const batteryLowMinimalistic = IconData(0xeda6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const batteryLow = IconData(0xeda7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const crownLine = IconData(0xeda8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const crownMinimalistic = IconData(0xeda9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const crownStar = IconData(0xedaa, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const crown = IconData(0xedab, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const database = IconData(0xedac, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const homeWiFiAngle = IconData(0xedad, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const pinCircle = IconData(0xedae, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const pinList = IconData(0xedaf, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const pin = IconData(0xedb0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sliderHorizontal = IconData(0xedb1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sliderMinimalisticHorizontal = IconData(0xedb2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sliderVerticalMinimalistic = IconData(0xedb3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sliderVertical = IconData(0xedb4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const smartHomeAngle = IconData(0xedb5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const trafficEconomy = IconData(0xedb6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const traffic = IconData(0xedb7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const trashBinMinimalistic = IconData(0xedb8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const trashBinTrash = IconData(0xedb9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const addSquare = IconData(0xedba, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const checkSquare = IconData(0xedbb, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const closeSquare = IconData(0xedbc, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const dangerSquare = IconData(0xedbd, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const dangerTriangle = IconData(0xedbe, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const danger = IconData(0xedbf, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const forbiddenCircle = IconData(0xedc0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const forbidden = IconData(0xedc1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const home2 = IconData(0xedc2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const homeAddAngle = IconData(0xedc3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const homeAdd = IconData(0xedc4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const homeAngle_2 = IconData(0xedc5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const homeAngle = IconData(0xedc6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const homeSmileAngle = IconData(0xedc7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const homeSmile = IconData(0xedc8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const homeWiFi = IconData(0xedc9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const home = IconData(0xedca, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const infoCircle = IconData(0xedcb, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const infoSquare = IconData(0xedcc, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const menuDotsCircle = IconData(0xedcd, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const menuDotsSquare = IconData(0xedce, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const menuDots = IconData(0xedcf, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const minusCircle = IconData(0xedd0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const minusSquare = IconData(0xedd1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const questionSquare = IconData(0xedd2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const revote = IconData(0xedd3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const smartHome = IconData(0xedd4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const addCircle = IconData(0xedd5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const checkCircle = IconData(0xedd6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const closeCircle = IconData(0xedd7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const dangerCircle = IconData(0xedd8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const questionCircle = IconData(0xedd9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const buildings_2 = IconData(0xedda, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const buildings_3 = IconData(0xeddb, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const buildings = IconData(0xeddc, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const city = IconData(0xeddd, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const garage = IconData(0xedde, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const home1 = IconData(0xeddf, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const hospital = IconData(0xede0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bus = IconData(0xede1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const electricRefueling = IconData(0xede2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const gasStation = IconData(0xede3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const kickScooter = IconData(0xede4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const scooter = IconData(0xede5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const speedometerLow = IconData(0xede6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const speedometerMax = IconData(0xede7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const speedometerMiddle = IconData(0xede8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const suspensionBolt = IconData(0xede9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const suspensionCross = IconData(0xedea, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const suspension = IconData(0xedeb, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const tram = IconData(0xedec, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const transmissionCircle = IconData(0xeded, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const transmissionSquare = IconData(0xedee, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const transmission = IconData(0xedef, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const wheelAngle = IconData(0xedf0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const wheel = IconData(0xedf1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const accumulator = IconData(0xedf2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const shockAbsorber = IconData(0xedf6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
 }

--- a/lib/src/solar_icons_broken.dart
+++ b/lib/src/solar_icons_broken.dart
@@ -1,2500 +1,1254 @@
-import 'solar_icons_data.dart';
+import 'package:flutter/widgets.dart';
 
 class SolarIconsBroken {
   SolarIconsBroken._();
 
-  static const String _fontFamily = 'SolarIconsBroken';
+  static const  _fontFamily = 'SolarIconsBroken';
 
-  static const SolarIconsData multipleForwardLeft =
-      SolarIconsData(0xe900, fontFamily: _fontFamily);
-  static const SolarIconsData multipleForwardRight =
-      SolarIconsData(0xe901, fontFamily: _fontFamily);
-  static const SolarIconsData paperclip2 =
-      SolarIconsData(0xe902, fontFamily: _fontFamily);
-  static const SolarIconsData paperclipRounded2 =
-      SolarIconsData(0xe903, fontFamily: _fontFamily);
-  static const SolarIconsData paperclipRounded =
-      SolarIconsData(0xe904, fontFamily: _fontFamily);
-  static const SolarIconsData paperclip =
-      SolarIconsData(0xe905, fontFamily: _fontFamily);
-  static const SolarIconsData plain2 =
-      SolarIconsData(0xe906, fontFamily: _fontFamily);
-  static const SolarIconsData plain3 =
-      SolarIconsData(0xe907, fontFamily: _fontFamily);
-  static const SolarIconsData plain =
-      SolarIconsData(0xe908, fontFamily: _fontFamily);
-  static const SolarIconsData squareForward =
-      SolarIconsData(0xe909, fontFamily: _fontFamily);
-  static const SolarIconsData squareShareLine =
-      SolarIconsData(0xe90a, fontFamily: _fontFamily);
-  static const SolarIconsData chatSquareArrow =
-      SolarIconsData(0xe90b, fontFamily: _fontFamily);
-  static const SolarIconsData chatSquareCall =
-      SolarIconsData(0xe90c, fontFamily: _fontFamily);
-  static const SolarIconsData chatRead =
-      SolarIconsData(0xe90d, fontFamily: _fontFamily);
-  static const SolarIconsData forward =
-      SolarIconsData(0xe90e, fontFamily: _fontFamily);
-  static const SolarIconsData inboxArchive =
-      SolarIconsData(0xe90f, fontFamily: _fontFamily);
-  static const SolarIconsData inboxIn =
-      SolarIconsData(0xe910, fontFamily: _fontFamily);
-  static const SolarIconsData inboxLine =
-      SolarIconsData(0xe911, fontFamily: _fontFamily);
-  static const SolarIconsData inboxOut =
-      SolarIconsData(0xe912, fontFamily: _fontFamily);
-  static const SolarIconsData inboxUnread =
-      SolarIconsData(0xe913, fontFamily: _fontFamily);
-  static const SolarIconsData inbox =
-      SolarIconsData(0xe914, fontFamily: _fontFamily);
-  static const SolarIconsData letterOpened =
-      SolarIconsData(0xe915, fontFamily: _fontFamily);
-  static const SolarIconsData letterUnread =
-      SolarIconsData(0xe916, fontFamily: _fontFamily);
-  static const SolarIconsData letter =
-      SolarIconsData(0xe917, fontFamily: _fontFamily);
-  static const SolarIconsData mailbox =
-      SolarIconsData(0xe918, fontFamily: _fontFamily);
-  static const SolarIconsData pen2 =
-      SolarIconsData(0xe919, fontFamily: _fontFamily);
-  static const SolarIconsData penNewRound =
-      SolarIconsData(0xe91a, fontFamily: _fontFamily);
-  static const SolarIconsData penNewSquare =
-      SolarIconsData(0xe91b, fontFamily: _fontFamily);
-  static const SolarIconsData pen =
-      SolarIconsData(0xe91c, fontFamily: _fontFamily);
-  static const SolarIconsData unread =
-      SolarIconsData(0xe91d, fontFamily: _fontFamily);
-  static const SolarIconsData chatSquareCheck =
-      SolarIconsData(0xe91e, fontFamily: _fontFamily);
-  static const SolarIconsData chatSquareCode =
-      SolarIconsData(0xe91f, fontFamily: _fontFamily);
-  static const SolarIconsData chatSquareLike =
-      SolarIconsData(0xe920, fontFamily: _fontFamily);
-  static const SolarIconsData chatSquare =
-      SolarIconsData(0xe921, fontFamily: _fontFamily);
-  static const SolarIconsData chatDots =
-      SolarIconsData(0xe922, fontFamily: _fontFamily);
-  static const SolarIconsData chatLine =
-      SolarIconsData(0xe923, fontFamily: _fontFamily);
-  static const SolarIconsData chatRoundCall =
-      SolarIconsData(0xe924, fontFamily: _fontFamily);
-  static const SolarIconsData chatRoundCheck =
-      SolarIconsData(0xe925, fontFamily: _fontFamily);
-  static const SolarIconsData chatRoundDots =
-      SolarIconsData(0xe926, fontFamily: _fontFamily);
-  static const SolarIconsData chatRoundLike =
-      SolarIconsData(0xe927, fontFamily: _fontFamily);
-  static const SolarIconsData chatRoundLine =
-      SolarIconsData(0xe928, fontFamily: _fontFamily);
-  static const SolarIconsData chatRoundMoney =
-      SolarIconsData(0xe929, fontFamily: _fontFamily);
-  static const SolarIconsData chatRoundUnread =
-      SolarIconsData(0xe92a, fontFamily: _fontFamily);
-  static const SolarIconsData chatRoundVideo =
-      SolarIconsData(0xe92b, fontFamily: _fontFamily);
-  static const SolarIconsData chatRound =
-      SolarIconsData(0xe92c, fontFamily: _fontFamily);
-  static const SolarIconsData chatUnread =
-      SolarIconsData(0xe92d, fontFamily: _fontFamily);
-  static const SolarIconsData dialog2 =
-      SolarIconsData(0xe92e, fontFamily: _fontFamily);
-  static const SolarIconsData dialog =
-      SolarIconsData(0xe92f, fontFamily: _fontFamily);
-  static const SolarIconsData refreshSquare =
-      SolarIconsData(0xe930, fontFamily: _fontFamily);
-  static const SolarIconsData restartCircle =
-      SolarIconsData(0xe931, fontFamily: _fontFamily);
-  static const SolarIconsData restartSquare =
-      SolarIconsData(0xe932, fontFamily: _fontFamily);
-  static const SolarIconsData altArrowDown =
-      SolarIconsData(0xe933, fontFamily: _fontFamily);
-  static const SolarIconsData altArrowLeft =
-      SolarIconsData(0xe934, fontFamily: _fontFamily);
-  static const SolarIconsData altArrowRight =
-      SolarIconsData(0xe935, fontFamily: _fontFamily);
-  static const SolarIconsData altArrowUp =
-      SolarIconsData(0xe936, fontFamily: _fontFamily);
-  static const SolarIconsData arrowDown =
-      SolarIconsData(0xe937, fontFamily: _fontFamily);
-  static const SolarIconsData arrowLeftDown =
-      SolarIconsData(0xe938, fontFamily: _fontFamily);
-  static const SolarIconsData arrowLeftUp =
-      SolarIconsData(0xe939, fontFamily: _fontFamily);
-  static const SolarIconsData arrowLeft =
-      SolarIconsData(0xe93a, fontFamily: _fontFamily);
-  static const SolarIconsData arrowRightDown =
-      SolarIconsData(0xe93b, fontFamily: _fontFamily);
-  static const SolarIconsData arrowRightUp =
-      SolarIconsData(0xe93c, fontFamily: _fontFamily);
-  static const SolarIconsData arrowRight =
-      SolarIconsData(0xe93d, fontFamily: _fontFamily);
-  static const SolarIconsData arrowUp =
-      SolarIconsData(0xe93e, fontFamily: _fontFamily);
-  static const SolarIconsData doubleAltArrowDown =
-      SolarIconsData(0xe93f, fontFamily: _fontFamily);
-  static const SolarIconsData doubleAltArrowLeft =
-      SolarIconsData(0xe940, fontFamily: _fontFamily);
-  static const SolarIconsData doubleAltArrowRight =
-      SolarIconsData(0xe941, fontFamily: _fontFamily);
-  static const SolarIconsData doubleAltArrowUp =
-      SolarIconsData(0xe942, fontFamily: _fontFamily);
-  static const SolarIconsData refreshCircle =
-      SolarIconsData(0xe943, fontFamily: _fontFamily);
-  static const SolarIconsData refresh =
-      SolarIconsData(0xe944, fontFamily: _fontFamily);
-  static const SolarIconsData restart =
-      SolarIconsData(0xe945, fontFamily: _fontFamily);
-  static const SolarIconsData roundAltArrowDown =
-      SolarIconsData(0xe946, fontFamily: _fontFamily);
-  static const SolarIconsData roundAltArrowUp =
-      SolarIconsData(0xe947, fontFamily: _fontFamily);
-  static const SolarIconsData roundArrowLeftUp =
-      SolarIconsData(0xe948, fontFamily: _fontFamily);
-  static const SolarIconsData roundArrowRightDown =
-      SolarIconsData(0xe949, fontFamily: _fontFamily);
-  static const SolarIconsData roundArrowRightUp =
-      SolarIconsData(0xe94a, fontFamily: _fontFamily);
-  static const SolarIconsData roundArrowRight =
-      SolarIconsData(0xe94b, fontFamily: _fontFamily);
-  static const SolarIconsData roundDoubleAltArrowDown =
-      SolarIconsData(0xe94c, fontFamily: _fontFamily);
-  static const SolarIconsData roundDoubleAltArrowLeft =
-      SolarIconsData(0xe94d, fontFamily: _fontFamily);
-  static const SolarIconsData roundDoubleAltArrowRight =
-      SolarIconsData(0xe94e, fontFamily: _fontFamily);
-  static const SolarIconsData roundDoubleAltArrowUp =
-      SolarIconsData(0xe94f, fontFamily: _fontFamily);
-  static const SolarIconsData roundSortHorizontal =
-      SolarIconsData(0xe950, fontFamily: _fontFamily);
-  static const SolarIconsData roundSortVertical =
-      SolarIconsData(0xe951, fontFamily: _fontFamily);
-  static const SolarIconsData roundTransferDiagonal =
-      SolarIconsData(0xe952, fontFamily: _fontFamily);
-  static const SolarIconsData roundTransferHorizontal =
-      SolarIconsData(0xe953, fontFamily: _fontFamily);
-  static const SolarIconsData roundTransferVertical =
-      SolarIconsData(0xe954, fontFamily: _fontFamily);
-  static const SolarIconsData sortHorizontal =
-      SolarIconsData(0xe955, fontFamily: _fontFamily);
-  static const SolarIconsData transferHorizontal =
-      SolarIconsData(0xe956, fontFamily: _fontFamily);
-  static const SolarIconsData transferVertical =
-      SolarIconsData(0xe957, fontFamily: _fontFamily);
-  static const SolarIconsData roundAltArrowLeft =
-      SolarIconsData(0xe958, fontFamily: _fontFamily);
-  static const SolarIconsData roundAltArrowRight =
-      SolarIconsData(0xe959, fontFamily: _fontFamily);
-  static const SolarIconsData roundArrowDown =
-      SolarIconsData(0xe95a, fontFamily: _fontFamily);
-  static const SolarIconsData roundArrowLeftDown =
-      SolarIconsData(0xe95b, fontFamily: _fontFamily);
-  static const SolarIconsData roundArrowLeft =
-      SolarIconsData(0xe95c, fontFamily: _fontFamily);
-  static const SolarIconsData roundArrowUp =
-      SolarIconsData(0xe95d, fontFamily: _fontFamily);
-  static const SolarIconsData squareAltArrowDown =
-      SolarIconsData(0xe95e, fontFamily: _fontFamily);
-  static const SolarIconsData squareArrowDown =
-      SolarIconsData(0xe95f, fontFamily: _fontFamily);
-  static const SolarIconsData squareArrowLeftDown =
-      SolarIconsData(0xe960, fontFamily: _fontFamily);
-  static const SolarIconsData squareArrowLeftUp =
-      SolarIconsData(0xe961, fontFamily: _fontFamily);
-  static const SolarIconsData squareArrowLeft =
-      SolarIconsData(0xe962, fontFamily: _fontFamily);
-  static const SolarIconsData squareArrowRightDown =
-      SolarIconsData(0xe963, fontFamily: _fontFamily);
-  static const SolarIconsData squareArrowRightUp =
-      SolarIconsData(0xe964, fontFamily: _fontFamily);
-  static const SolarIconsData squareArrowRight =
-      SolarIconsData(0xe965, fontFamily: _fontFamily);
-  static const SolarIconsData squareArrowUp =
-      SolarIconsData(0xe966, fontFamily: _fontFamily);
-  static const SolarIconsData squareSortHorizontal =
-      SolarIconsData(0xe967, fontFamily: _fontFamily);
-  static const SolarIconsData squareSortVertical =
-      SolarIconsData(0xe968, fontFamily: _fontFamily);
-  static const SolarIconsData squareTransferHorizontal =
-      SolarIconsData(0xe969, fontFamily: _fontFamily);
-  static const SolarIconsData squareTransferVertical =
-      SolarIconsData(0xe96a, fontFamily: _fontFamily);
-  static const SolarIconsData squareAltArrowLeft =
-      SolarIconsData(0xe96b, fontFamily: _fontFamily);
-  static const SolarIconsData squareAltArrowRight =
-      SolarIconsData(0xe96c, fontFamily: _fontFamily);
-  static const SolarIconsData squareAltArrowUp =
-      SolarIconsData(0xe96d, fontFamily: _fontFamily);
-  static const SolarIconsData squareDoubleAltArrowRight =
-      SolarIconsData(0xe96e, fontFamily: _fontFamily);
-  static const SolarIconsData squareDoubleAltArrowDown =
-      SolarIconsData(0xe96f, fontFamily: _fontFamily);
-  static const SolarIconsData squareDoubleAltArrowLeft =
-      SolarIconsData(0xe970, fontFamily: _fontFamily);
-  static const SolarIconsData squareDoubleAltArrowUp =
-      SolarIconsData(0xe971, fontFamily: _fontFamily);
-  static const SolarIconsData compassBig =
-      SolarIconsData(0xe972, fontFamily: _fontFamily);
-  static const SolarIconsData globus =
-      SolarIconsData(0xe973, fontFamily: _fontFamily);
-  static const SolarIconsData gps =
-      SolarIconsData(0xe974, fontFamily: _fontFamily);
-  static const SolarIconsData branchingPathsDown =
-      SolarIconsData(0xe975, fontFamily: _fontFamily);
-  static const SolarIconsData branchingPathsUp =
-      SolarIconsData(0xe976, fontFamily: _fontFamily);
-  static const SolarIconsData mapArrowDown =
-      SolarIconsData(0xe977, fontFamily: _fontFamily);
-  static const SolarIconsData mapArrowLeft =
-      SolarIconsData(0xe978, fontFamily: _fontFamily);
-  static const SolarIconsData mapArrowRight =
-      SolarIconsData(0xe979, fontFamily: _fontFamily);
-  static const SolarIconsData mapArrowSquare =
-      SolarIconsData(0xe97a, fontFamily: _fontFamily);
-  static const SolarIconsData mapArrowUp =
-      SolarIconsData(0xe97b, fontFamily: _fontFamily);
-  static const SolarIconsData pointOnMapPerspective =
-      SolarIconsData(0xe97c, fontFamily: _fontFamily);
-  static const SolarIconsData radar2 =
-      SolarIconsData(0xe97d, fontFamily: _fontFamily);
-  static const SolarIconsData radar =
-      SolarIconsData(0xe97e, fontFamily: _fontFamily);
-  static const SolarIconsData route =
-      SolarIconsData(0xe97f, fontFamily: _fontFamily);
-  static const SolarIconsData routing2 =
-      SolarIconsData(0xe980, fontFamily: _fontFamily);
-  static const SolarIconsData routing3 =
-      SolarIconsData(0xe981, fontFamily: _fontFamily);
-  static const SolarIconsData routing =
-      SolarIconsData(0xe982, fontFamily: _fontFamily);
-  static const SolarIconsData signpost2 =
-      SolarIconsData(0xe983, fontFamily: _fontFamily);
-  static const SolarIconsData signpost =
-      SolarIconsData(0xe984, fontFamily: _fontFamily);
-  static const SolarIconsData streetsMapPoint =
-      SolarIconsData(0xe985, fontFamily: _fontFamily);
-  static const SolarIconsData streetsNavigation =
-      SolarIconsData(0xe986, fontFamily: _fontFamily);
-  static const SolarIconsData streets =
-      SolarIconsData(0xe987, fontFamily: _fontFamily);
-  static const SolarIconsData compassSquare =
-      SolarIconsData(0xe988, fontFamily: _fontFamily);
-  static const SolarIconsData compass =
-      SolarIconsData(0xe989, fontFamily: _fontFamily);
-  static const SolarIconsData global =
-      SolarIconsData(0xe98a, fontFamily: _fontFamily);
-  static const SolarIconsData mapPointAdd =
-      SolarIconsData(0xe98b, fontFamily: _fontFamily);
-  static const SolarIconsData mapPointFavourite =
-      SolarIconsData(0xe98c, fontFamily: _fontFamily);
-  static const SolarIconsData mapPointHospital =
-      SolarIconsData(0xe98d, fontFamily: _fontFamily);
-  static const SolarIconsData mapPointRemove =
-      SolarIconsData(0xe98e, fontFamily: _fontFamily);
-  static const SolarIconsData mapPointRotate =
-      SolarIconsData(0xe98f, fontFamily: _fontFamily);
-  static const SolarIconsData mapPointSchool =
-      SolarIconsData(0xe990, fontFamily: _fontFamily);
-  static const SolarIconsData mapPointSearch =
-      SolarIconsData(0xe991, fontFamily: _fontFamily);
-  static const SolarIconsData mapPointWave =
-      SolarIconsData(0xe992, fontFamily: _fontFamily);
-  static const SolarIconsData mapPoint =
-      SolarIconsData(0xe993, fontFamily: _fontFamily);
-  static const SolarIconsData map =
-      SolarIconsData(0xe994, fontFamily: _fontFamily);
-  static const SolarIconsData peopleNearby =
-      SolarIconsData(0xe995, fontFamily: _fontFamily);
-  static const SolarIconsData pointOnMap =
-      SolarIconsData(0xe996, fontFamily: _fontFamily);
-  static const SolarIconsData banknote2 =
-      SolarIconsData(0xe997, fontFamily: _fontFamily);
-  static const SolarIconsData banknote =
-      SolarIconsData(0xe998, fontFamily: _fontFamily);
-  static const SolarIconsData billCheck =
-      SolarIconsData(0xe999, fontFamily: _fontFamily);
-  static const SolarIconsData billCross =
-      SolarIconsData(0xe99a, fontFamily: _fontFamily);
-  static const SolarIconsData billList =
-      SolarIconsData(0xe99b, fontFamily: _fontFamily);
-  static const SolarIconsData bill =
-      SolarIconsData(0xe99c, fontFamily: _fontFamily);
-  static const SolarIconsData cashOut =
-      SolarIconsData(0xe99d, fontFamily: _fontFamily);
-  static const SolarIconsData dollarMinimalistic =
-      SolarIconsData(0xe99e, fontFamily: _fontFamily);
-  static const SolarIconsData dollar =
-      SolarIconsData(0xe99f, fontFamily: _fontFamily);
-  static const SolarIconsData moneyBag =
-      SolarIconsData(0xe9a0, fontFamily: _fontFamily);
-  static const SolarIconsData ruble =
-      SolarIconsData(0xe9a1, fontFamily: _fontFamily);
-  static const SolarIconsData safe2 =
-      SolarIconsData(0xe9a2, fontFamily: _fontFamily);
-  static const SolarIconsData safeCircle =
-      SolarIconsData(0xe9a3, fontFamily: _fontFamily);
-  static const SolarIconsData safeSquare =
-      SolarIconsData(0xe9a4, fontFamily: _fontFamily);
-  static const SolarIconsData wadOfMoney =
-      SolarIconsData(0xe9a5, fontFamily: _fontFamily);
-  static const SolarIconsData card2 =
-      SolarIconsData(0xe9a6, fontFamily: _fontFamily);
-  static const SolarIconsData cardReceive =
-      SolarIconsData(0xe9a7, fontFamily: _fontFamily);
-  static const SolarIconsData cardSearch =
-      SolarIconsData(0xe9a8, fontFamily: _fontFamily);
-  static const SolarIconsData cardSend =
-      SolarIconsData(0xe9a9, fontFamily: _fontFamily);
-  static const SolarIconsData cardTransfer =
-      SolarIconsData(0xe9aa, fontFamily: _fontFamily);
-  static const SolarIconsData card =
-      SolarIconsData(0xe9ab, fontFamily: _fontFamily);
-  static const SolarIconsData cardholder =
-      SolarIconsData(0xe9ac, fontFamily: _fontFamily);
-  static const SolarIconsData euro =
-      SolarIconsData(0xe9ad, fontFamily: _fontFamily);
-  static const SolarIconsData saleSquare =
-      SolarIconsData(0xe9ae, fontFamily: _fontFamily);
-  static const SolarIconsData sale =
-      SolarIconsData(0xe9af, fontFamily: _fontFamily);
-  static const SolarIconsData tagHorizontal =
-      SolarIconsData(0xe9b0, fontFamily: _fontFamily);
-  static const SolarIconsData tagPrice =
-      SolarIconsData(0xe9b1, fontFamily: _fontFamily);
-  static const SolarIconsData tag =
-      SolarIconsData(0xe9b2, fontFamily: _fontFamily);
-  static const SolarIconsData tickerStar =
-      SolarIconsData(0xe9b3, fontFamily: _fontFamily);
-  static const SolarIconsData ticketSale =
-      SolarIconsData(0xe9b4, fontFamily: _fontFamily);
-  static const SolarIconsData ticket =
-      SolarIconsData(0xe9b5, fontFamily: _fontFamily);
-  static const SolarIconsData verifiedCheck =
-      SolarIconsData(0xe9b6, fontFamily: _fontFamily);
-  static const SolarIconsData wallet2 =
-      SolarIconsData(0xe9b7, fontFamily: _fontFamily);
-  static const SolarIconsData walletMoney =
-      SolarIconsData(0xe9b8, fontFamily: _fontFamily);
-  static const SolarIconsData wallet =
-      SolarIconsData(0xe9b9, fontFamily: _fontFamily);
-  static const SolarIconsData flashDrive =
-      SolarIconsData(0xe9ba, fontFamily: _fontFamily);
-  static const SolarIconsData lightbulbBold =
-      SolarIconsData(0xe9bb, fontFamily: _fontFamily);
-  static const SolarIconsData lightbulbMinimalistic =
-      SolarIconsData(0xe9bc, fontFamily: _fontFamily);
-  static const SolarIconsData lightbulb =
-      SolarIconsData(0xe9bd, fontFamily: _fontFamily);
-  static const SolarIconsData lightning =
-      SolarIconsData(0xe9be, fontFamily: _fontFamily);
-  static const SolarIconsData socket =
-      SolarIconsData(0xe9bf, fontFamily: _fontFamily);
-  static const SolarIconsData weigher =
-      SolarIconsData(0xe9c0, fontFamily: _fontFamily);
-  static const SolarIconsData bluetoothCircle =
-      SolarIconsData(0xe9c1, fontFamily: _fontFamily);
-  static const SolarIconsData bluetoothSquare =
-      SolarIconsData(0xe9c2, fontFamily: _fontFamily);
-  static const SolarIconsData cloudStorage =
-      SolarIconsData(0xe9c3, fontFamily: _fontFamily);
-  static const SolarIconsData devices =
-      SolarIconsData(0xe9c4, fontFamily: _fontFamily);
-  static const SolarIconsData diskette =
-      SolarIconsData(0xe9c5, fontFamily: _fontFamily);
-  static const SolarIconsData display =
-      SolarIconsData(0xe9c6, fontFamily: _fontFamily);
-  static const SolarIconsData gameboy =
-      SolarIconsData(0xe9c7, fontFamily: _fontFamily);
-  static const SolarIconsData keyboard =
-      SolarIconsData(0xe9c8, fontFamily: _fontFamily);
-  static const SolarIconsData plugCircle =
-      SolarIconsData(0xe9c9, fontFamily: _fontFamily);
-  static const SolarIconsData projector =
-      SolarIconsData(0xe9ca, fontFamily: _fontFamily);
-  static const SolarIconsData radioMinimalistic =
-      SolarIconsData(0xe9cb, fontFamily: _fontFamily);
-  static const SolarIconsData radio =
-      SolarIconsData(0xe9cc, fontFamily: _fontFamily);
-  static const SolarIconsData sdCard =
-      SolarIconsData(0xe9cd, fontFamily: _fontFamily);
-  static const SolarIconsData simCardMinimalistic =
-      SolarIconsData(0xe9ce, fontFamily: _fontFamily);
-  static const SolarIconsData simCard =
-      SolarIconsData(0xe9cf, fontFamily: _fontFamily);
-  static const SolarIconsData simCards =
-      SolarIconsData(0xe9d0, fontFamily: _fontFamily);
-  static const SolarIconsData smartSpeaker2 =
-      SolarIconsData(0xe9d1, fontFamily: _fontFamily);
-  static const SolarIconsData smartSpeakerMinimalistic =
-      SolarIconsData(0xe9d2, fontFamily: _fontFamily);
-  static const SolarIconsData smartSpeaker =
-      SolarIconsData(0xe9d3, fontFamily: _fontFamily);
-  static const SolarIconsData ssdRound =
-      SolarIconsData(0xe9d4, fontFamily: _fontFamily);
-  static const SolarIconsData ssdSquare =
-      SolarIconsData(0xe9d5, fontFamily: _fontFamily);
-  static const SolarIconsData telescope =
-      SolarIconsData(0xe9d6, fontFamily: _fontFamily);
-  static const SolarIconsData tv =
-      SolarIconsData(0xe9d7, fontFamily: _fontFamily);
-  static const SolarIconsData wirelessCharge =
-      SolarIconsData(0xe9d8, fontFamily: _fontFamily);
-  static const SolarIconsData airbudsCharge =
-      SolarIconsData(0xe9d9, fontFamily: _fontFamily);
-  static const SolarIconsData airbudsLeft =
-      SolarIconsData(0xe9da, fontFamily: _fontFamily);
-  static const SolarIconsData airbudsRemove =
-      SolarIconsData(0xe9db, fontFamily: _fontFamily);
-  static const SolarIconsData airbudsRight =
-      SolarIconsData(0xe9dc, fontFamily: _fontFamily);
-  static const SolarIconsData bluetoothWave =
-      SolarIconsData(0xe9dd, fontFamily: _fontFamily);
-  static const SolarIconsData bluetooth =
-      SolarIconsData(0xe9de, fontFamily: _fontFamily);
-  static const SolarIconsData boombox =
-      SolarIconsData(0xe9df, fontFamily: _fontFamily);
-  static const SolarIconsData cassette2 =
-      SolarIconsData(0xe9e0, fontFamily: _fontFamily);
-  static const SolarIconsData cassette =
-      SolarIconsData(0xe9e1, fontFamily: _fontFamily);
-  static const SolarIconsData cpuBolt =
-      SolarIconsData(0xe9e2, fontFamily: _fontFamily);
-  static const SolarIconsData cpu =
-      SolarIconsData(0xe9e3, fontFamily: _fontFamily);
-  static const SolarIconsData laptop2 =
-      SolarIconsData(0xe9e4, fontFamily: _fontFamily);
-  static const SolarIconsData laptop3 =
-      SolarIconsData(0xe9e5, fontFamily: _fontFamily);
-  static const SolarIconsData laptopMinimalistic =
-      SolarIconsData(0xe9e6, fontFamily: _fontFamily);
-  static const SolarIconsData laptop =
-      SolarIconsData(0xe9e7, fontFamily: _fontFamily);
-  static const SolarIconsData monitorCamera =
-      SolarIconsData(0xe9e8, fontFamily: _fontFamily);
-  static const SolarIconsData monitorSmartphone =
-      SolarIconsData(0xe9e9, fontFamily: _fontFamily);
-  static const SolarIconsData monitor =
-      SolarIconsData(0xe9ea, fontFamily: _fontFamily);
-  static const SolarIconsData printer2 =
-      SolarIconsData(0xe9eb, fontFamily: _fontFamily);
-  static const SolarIconsData printerMinimalistic =
-      SolarIconsData(0xe9ec, fontFamily: _fontFamily);
-  static const SolarIconsData printer =
-      SolarIconsData(0xe9ed, fontFamily: _fontFamily);
-  static const SolarIconsData turntableMinimalistic =
-      SolarIconsData(0xe9ee, fontFamily: _fontFamily);
-  static const SolarIconsData turntableMusicNote =
-      SolarIconsData(0xe9ef, fontFamily: _fontFamily);
-  static const SolarIconsData turntable =
-      SolarIconsData(0xe9f0, fontFamily: _fontFamily);
-  static const SolarIconsData airbudsCaseCharge =
-      SolarIconsData(0xe9f1, fontFamily: _fontFamily);
-  static const SolarIconsData airbudsCaseMinimalistic =
-      SolarIconsData(0xe9f2, fontFamily: _fontFamily);
-  static const SolarIconsData airbudsCaseOpen =
-      SolarIconsData(0xe9f3, fontFamily: _fontFamily);
-  static const SolarIconsData airbudsCase =
-      SolarIconsData(0xe9f4, fontFamily: _fontFamily);
-  static const SolarIconsData airbudsCheck =
-      SolarIconsData(0xe9f5, fontFamily: _fontFamily);
-  static const SolarIconsData airbuds =
-      SolarIconsData(0xe9f6, fontFamily: _fontFamily);
-  static const SolarIconsData headphonesRoundSound =
-      SolarIconsData(0xe9f7, fontFamily: _fontFamily);
-  static const SolarIconsData headphonesRound =
-      SolarIconsData(0xe9f8, fontFamily: _fontFamily);
-  static const SolarIconsData headphonesSquareSound =
-      SolarIconsData(0xe9f9, fontFamily: _fontFamily);
-  static const SolarIconsData headphonesSquare =
-      SolarIconsData(0xe9fa, fontFamily: _fontFamily);
-  static const SolarIconsData mouseCircle =
-      SolarIconsData(0xe9fb, fontFamily: _fontFamily);
-  static const SolarIconsData mouseMinimalistic =
-      SolarIconsData(0xe9fc, fontFamily: _fontFamily);
-  static const SolarIconsData mouse =
-      SolarIconsData(0xe9fd, fontFamily: _fontFamily);
-  static const SolarIconsData server2 =
-      SolarIconsData(0xe9fe, fontFamily: _fontFamily);
-  static const SolarIconsData serverMinimalistic =
-      SolarIconsData(0xe9ff, fontFamily: _fontFamily);
-  static const SolarIconsData serverPath =
-      SolarIconsData(0xea00, fontFamily: _fontFamily);
-  static const SolarIconsData serverSquareCloud =
-      SolarIconsData(0xea01, fontFamily: _fontFamily);
-  static const SolarIconsData serverSquareUpdate =
-      SolarIconsData(0xea02, fontFamily: _fontFamily);
-  static const SolarIconsData serverSquare =
-      SolarIconsData(0xea03, fontFamily: _fontFamily);
-  static const SolarIconsData server =
-      SolarIconsData(0xea04, fontFamily: _fontFamily);
-  static const SolarIconsData smartphoneRotate2 =
-      SolarIconsData(0xea05, fontFamily: _fontFamily);
-  static const SolarIconsData smartphoneRotateAngle =
-      SolarIconsData(0xea06, fontFamily: _fontFamily);
-  static const SolarIconsData smartphoneRotateOrientation =
-      SolarIconsData(0xea07, fontFamily: _fontFamily);
-  static const SolarIconsData smartphoneVibration =
-      SolarIconsData(0xea08, fontFamily: _fontFamily);
-  static const SolarIconsData tablet =
-      SolarIconsData(0xea09, fontFamily: _fontFamily);
-  static const SolarIconsData gamepadCharge =
-      SolarIconsData(0xea0a, fontFamily: _fontFamily);
-  static const SolarIconsData gamepadMinimalistic =
-      SolarIconsData(0xea0b, fontFamily: _fontFamily);
-  static const SolarIconsData gamepadNoCharge =
-      SolarIconsData(0xea0c, fontFamily: _fontFamily);
-  static const SolarIconsData gamepadOld =
-      SolarIconsData(0xea0d, fontFamily: _fontFamily);
-  static const SolarIconsData gamepad =
-      SolarIconsData(0xea0e, fontFamily: _fontFamily);
-  static const SolarIconsData iPhone =
-      SolarIconsData(0xea0f, fontFamily: _fontFamily);
-  static const SolarIconsData smartphone2 =
-      SolarIconsData(0xea10, fontFamily: _fontFamily);
-  static const SolarIconsData smartphoneUpdate =
-      SolarIconsData(0xea11, fontFamily: _fontFamily);
-  static const SolarIconsData smartphone =
-      SolarIconsData(0xea12, fontFamily: _fontFamily);
-  static const SolarIconsData cloudDownload =
-      SolarIconsData(0xea13, fontFamily: _fontFamily);
-  static const SolarIconsData cloudSnowfallMinimalistic =
-      SolarIconsData(0xea14, fontFamily: _fontFamily);
-  static const SolarIconsData cloudUpload =
-      SolarIconsData(0xea15, fontFamily: _fontFamily);
-  static const SolarIconsData cloudyMoon =
-      SolarIconsData(0xea16, fontFamily: _fontFamily);
-  static const SolarIconsData moonFog =
-      SolarIconsData(0xea17, fontFamily: _fontFamily);
-  static const SolarIconsData moonSleep =
-      SolarIconsData(0xea18, fontFamily: _fontFamily);
-  static const SolarIconsData moonStars =
-      SolarIconsData(0xea19, fontFamily: _fontFamily);
-  static const SolarIconsData moon =
-      SolarIconsData(0xea1a, fontFamily: _fontFamily);
-  static const SolarIconsData snowflake =
-      SolarIconsData(0xea1b, fontFamily: _fontFamily);
-  static const SolarIconsData stars =
-      SolarIconsData(0xea1c, fontFamily: _fontFamily);
-  static const SolarIconsData sun2 =
-      SolarIconsData(0xea1d, fontFamily: _fontFamily);
-  static const SolarIconsData sunfog =
-      SolarIconsData(0xea1e, fontFamily: _fontFamily);
-  static const SolarIconsData sun =
-      SolarIconsData(0xea1f, fontFamily: _fontFamily);
-  static const SolarIconsData sunrise =
-      SolarIconsData(0xea20, fontFamily: _fontFamily);
-  static const SolarIconsData sunset =
-      SolarIconsData(0xea21, fontFamily: _fontFamily);
-  static const SolarIconsData temperature =
-      SolarIconsData(0xea22, fontFamily: _fontFamily);
-  static const SolarIconsData tornadoSmall =
-      SolarIconsData(0xea23, fontFamily: _fontFamily);
-  static const SolarIconsData waterdrops =
-      SolarIconsData(0xea24, fontFamily: _fontFamily);
-  static const SolarIconsData wind =
-      SolarIconsData(0xea25, fontFamily: _fontFamily);
-  static const SolarIconsData cloudBoltMinimalistic =
-      SolarIconsData(0xea26, fontFamily: _fontFamily);
-  static const SolarIconsData cloudBolt =
-      SolarIconsData(0xea27, fontFamily: _fontFamily);
-  static const SolarIconsData cloudCheck =
-      SolarIconsData(0xea28, fontFamily: _fontFamily);
-  static const SolarIconsData cloudMinus =
-      SolarIconsData(0xea29, fontFamily: _fontFamily);
-  static const SolarIconsData cloudPlus =
-      SolarIconsData(0xea2a, fontFamily: _fontFamily);
-  static const SolarIconsData cloudRain =
-      SolarIconsData(0xea2b, fontFamily: _fontFamily);
-  static const SolarIconsData cloudSnowfall =
-      SolarIconsData(0xea2c, fontFamily: _fontFamily);
-  static const SolarIconsData cloudStorm =
-      SolarIconsData(0xea2d, fontFamily: _fontFamily);
-  static const SolarIconsData cloudSun2 =
-      SolarIconsData(0xea2e, fontFamily: _fontFamily);
-  static const SolarIconsData cloudSun =
-      SolarIconsData(0xea2f, fontFamily: _fontFamily);
-  static const SolarIconsData cloudWaterdrop =
-      SolarIconsData(0xea30, fontFamily: _fontFamily);
-  static const SolarIconsData cloudWaterdrops =
-      SolarIconsData(0xea31, fontFamily: _fontFamily);
-  static const SolarIconsData cloud =
-      SolarIconsData(0xea32, fontFamily: _fontFamily);
-  static const SolarIconsData clouds =
-      SolarIconsData(0xea33, fontFamily: _fontFamily);
-  static const SolarIconsData cloudCross =
-      SolarIconsData(0xea34, fontFamily: _fontFamily);
-  static const SolarIconsData fog =
-      SolarIconsData(0xea35, fontFamily: _fontFamily);
-  static const SolarIconsData tornado =
-      SolarIconsData(0xea36, fontFamily: _fontFamily);
-  static const SolarIconsData cloudFile =
-      SolarIconsData(0xea37, fontFamily: _fontFamily);
-  static const SolarIconsData codeFile =
-      SolarIconsData(0xea38, fontFamily: _fontFamily);
-  static const SolarIconsData figmaFile =
-      SolarIconsData(0xea39, fontFamily: _fontFamily);
-  static const SolarIconsData fileCorrupted =
-      SolarIconsData(0xea3a, fontFamily: _fontFamily);
-  static const SolarIconsData fileDownload =
-      SolarIconsData(0xea3b, fontFamily: _fontFamily);
-  static const SolarIconsData fileLeft =
-      SolarIconsData(0xea3c, fontFamily: _fontFamily);
-  static const SolarIconsData fileRight =
-      SolarIconsData(0xea3d, fontFamily: _fontFamily);
-  static const SolarIconsData fileSmile =
-      SolarIconsData(0xea3e, fontFamily: _fontFamily);
-  static const SolarIconsData zipFile =
-      SolarIconsData(0xea3f, fontFamily: _fontFamily);
-  static const SolarIconsData fileCheck =
-      SolarIconsData(0xea40, fontFamily: _fontFamily);
-  static const SolarIconsData fileFavourite =
-      SolarIconsData(0xea41, fontFamily: _fontFamily);
-  static const SolarIconsData fileRemove =
-      SolarIconsData(0xea42, fontFamily: _fontFamily);
-  static const SolarIconsData fileSend =
-      SolarIconsData(0xea43, fontFamily: _fontFamily);
-  static const SolarIconsData fileText =
-      SolarIconsData(0xea44, fontFamily: _fontFamily);
-  static const SolarIconsData file =
-      SolarIconsData(0xea45, fontFamily: _fontFamily);
-  static const SolarIconsData folderOpen =
-      SolarIconsData(0xea46, fontFamily: _fontFamily);
-  static const SolarIconsData addFolder =
-      SolarIconsData(0xea47, fontFamily: _fontFamily);
-  static const SolarIconsData folder2 =
-      SolarIconsData(0xea48, fontFamily: _fontFamily);
-  static const SolarIconsData folderCheck =
-      SolarIconsData(0xea49, fontFamily: _fontFamily);
-  static const SolarIconsData folderCloud =
-      SolarIconsData(0xea4a, fontFamily: _fontFamily);
-  static const SolarIconsData folderError =
-      SolarIconsData(0xea4b, fontFamily: _fontFamily);
-  static const SolarIconsData folderFavouriteBookmark =
-      SolarIconsData(0xea4c, fontFamily: _fontFamily);
-  static const SolarIconsData folderFavouriteStar =
-      SolarIconsData(0xea4d, fontFamily: _fontFamily);
-  static const SolarIconsData folderPathConnect =
-      SolarIconsData(0xea4e, fontFamily: _fontFamily);
-  static const SolarIconsData folderSecurity =
-      SolarIconsData(0xea4f, fontFamily: _fontFamily);
-  static const SolarIconsData folderWithFiles =
-      SolarIconsData(0xea50, fontFamily: _fontFamily);
-  static const SolarIconsData folder =
-      SolarIconsData(0xea51, fontFamily: _fontFamily);
-  static const SolarIconsData moveToFolder =
-      SolarIconsData(0xea52, fontFamily: _fontFamily);
-  static const SolarIconsData removeFolder =
-      SolarIconsData(0xea53, fontFamily: _fontFamily);
-  static const SolarIconsData starFall2 =
-      SolarIconsData(0xea54, fontFamily: _fontFamily);
-  static const SolarIconsData starFallMinimalistic2 =
-      SolarIconsData(0xea55, fontFamily: _fontFamily);
-  static const SolarIconsData starFallMinimalistic =
-      SolarIconsData(0xea56, fontFamily: _fontFamily);
-  static const SolarIconsData starFall =
-      SolarIconsData(0xea57, fontFamily: _fontFamily);
-  static const SolarIconsData starRainbow =
-      SolarIconsData(0xea58, fontFamily: _fontFamily);
-  static const SolarIconsData starRing =
-      SolarIconsData(0xea59, fontFamily: _fontFamily);
-  static const SolarIconsData starRings =
-      SolarIconsData(0xea5a, fontFamily: _fontFamily);
-  static const SolarIconsData star =
-      SolarIconsData(0xea5b, fontFamily: _fontFamily);
-  static const SolarIconsData starsLine =
-      SolarIconsData(0xea5c, fontFamily: _fontFamily);
-  static const SolarIconsData starsMinimalistic =
-      SolarIconsData(0xea5d, fontFamily: _fontFamily);
-  static const SolarIconsData stars1 =
-      SolarIconsData(0xea5e, fontFamily: _fontFamily);
-  static const SolarIconsData ufo2 =
-      SolarIconsData(0xea5f, fontFamily: _fontFamily);
-  static const SolarIconsData ufo3 =
-      SolarIconsData(0xea60, fontFamily: _fontFamily);
-  static const SolarIconsData ufo =
-      SolarIconsData(0xea61, fontFamily: _fontFamily);
-  static const SolarIconsData asteroid =
-      SolarIconsData(0xea62, fontFamily: _fontFamily);
-  static const SolarIconsData atom =
-      SolarIconsData(0xea63, fontFamily: _fontFamily);
-  static const SolarIconsData blackHole2 =
-      SolarIconsData(0xea64, fontFamily: _fontFamily);
-  static const SolarIconsData blackHole3 =
-      SolarIconsData(0xea65, fontFamily: _fontFamily);
-  static const SolarIconsData blackHole =
-      SolarIconsData(0xea66, fontFamily: _fontFamily);
-  static const SolarIconsData earth =
-      SolarIconsData(0xea67, fontFamily: _fontFamily);
-  static const SolarIconsData infinity =
-      SolarIconsData(0xea68, fontFamily: _fontFamily);
-  static const SolarIconsData men =
-      SolarIconsData(0xea69, fontFamily: _fontFamily);
-  static const SolarIconsData planet2 =
-      SolarIconsData(0xea6a, fontFamily: _fontFamily);
-  static const SolarIconsData planet3 =
-      SolarIconsData(0xea6b, fontFamily: _fontFamily);
-  static const SolarIconsData planet4 =
-      SolarIconsData(0xea6c, fontFamily: _fontFamily);
-  static const SolarIconsData planet =
-      SolarIconsData(0xea6d, fontFamily: _fontFamily);
-  static const SolarIconsData rocket2 =
-      SolarIconsData(0xea6e, fontFamily: _fontFamily);
-  static const SolarIconsData rocket =
-      SolarIconsData(0xea6f, fontFamily: _fontFamily);
-  static const SolarIconsData satellite =
-      SolarIconsData(0xea70, fontFamily: _fontFamily);
-  static const SolarIconsData starAngle =
-      SolarIconsData(0xea71, fontFamily: _fontFamily);
-  static const SolarIconsData starCircle =
-      SolarIconsData(0xea72, fontFamily: _fontFamily);
-  static const SolarIconsData women =
-      SolarIconsData(0xea73, fontFamily: _fontFamily);
-  static const SolarIconsData confoundedCircle =
-      SolarIconsData(0xea74, fontFamily: _fontFamily);
-  static const SolarIconsData confoundedSquare =
-      SolarIconsData(0xea75, fontFamily: _fontFamily);
-  static const SolarIconsData emojiFunnyCircle =
-      SolarIconsData(0xea76, fontFamily: _fontFamily);
-  static const SolarIconsData emojiFunnySquare =
-      SolarIconsData(0xea77, fontFamily: _fontFamily);
-  static const SolarIconsData expressionlessCircle =
-      SolarIconsData(0xea78, fontFamily: _fontFamily);
-  static const SolarIconsData expressionlessSquare =
-      SolarIconsData(0xea79, fontFamily: _fontFamily);
-  static const SolarIconsData faceScanCircle =
-      SolarIconsData(0xea7a, fontFamily: _fontFamily);
-  static const SolarIconsData faceScanSquare =
-      SolarIconsData(0xea7b, fontFamily: _fontFamily);
-  static const SolarIconsData facemaskCircle =
-      SolarIconsData(0xea7c, fontFamily: _fontFamily);
-  static const SolarIconsData facemaskSquare =
-      SolarIconsData(0xea7d, fontFamily: _fontFamily);
-  static const SolarIconsData sadCircle =
-      SolarIconsData(0xea7e, fontFamily: _fontFamily);
-  static const SolarIconsData sadSquare =
-      SolarIconsData(0xea7f, fontFamily: _fontFamily);
-  static const SolarIconsData sleepingCircle =
-      SolarIconsData(0xea80, fontFamily: _fontFamily);
-  static const SolarIconsData sleepingSquare =
-      SolarIconsData(0xea81, fontFamily: _fontFamily);
-  static const SolarIconsData smileCircle =
-      SolarIconsData(0xea82, fontFamily: _fontFamily);
-  static const SolarIconsData smileSquare =
-      SolarIconsData(0xea83, fontFamily: _fontFamily);
-  static const SolarIconsData stickerCircle =
-      SolarIconsData(0xea84, fontFamily: _fontFamily);
-  static const SolarIconsData stickerSmileCircle2 =
-      SolarIconsData(0xea85, fontFamily: _fontFamily);
-  static const SolarIconsData stickerSmileCircle =
-      SolarIconsData(0xea86, fontFamily: _fontFamily);
-  static const SolarIconsData stickerSmileSquare =
-      SolarIconsData(0xea87, fontFamily: _fontFamily);
-  static const SolarIconsData stickerSquare =
-      SolarIconsData(0xea88, fontFamily: _fontFamily);
-  static const SolarIconsData balls =
-      SolarIconsData(0xea89, fontFamily: _fontFamily);
-  static const SolarIconsData basketball =
-      SolarIconsData(0xea8a, fontFamily: _fontFamily);
-  static const SolarIconsData bowling =
-      SolarIconsData(0xea8b, fontFamily: _fontFamily);
-  static const SolarIconsData football =
-      SolarIconsData(0xea8c, fontFamily: _fontFamily);
-  static const SolarIconsData rugby =
-      SolarIconsData(0xea8d, fontFamily: _fontFamily);
-  static const SolarIconsData tennis2 =
-      SolarIconsData(0xea8e, fontFamily: _fontFamily);
-  static const SolarIconsData tennis =
-      SolarIconsData(0xea8f, fontFamily: _fontFamily);
-  static const SolarIconsData volleyball2 =
-      SolarIconsData(0xea90, fontFamily: _fontFamily);
-  static const SolarIconsData volleyball =
-      SolarIconsData(0xea91, fontFamily: _fontFamily);
-  static const SolarIconsData bodyShapeMinimalistic =
-      SolarIconsData(0xea92, fontFamily: _fontFamily);
-  static const SolarIconsData bodyShape =
-      SolarIconsData(0xea93, fontFamily: _fontFamily);
-  static const SolarIconsData dumbbellLargeMinimalistic =
-      SolarIconsData(0xea94, fontFamily: _fontFamily);
-  static const SolarIconsData dumbbellLarge =
-      SolarIconsData(0xea95, fontFamily: _fontFamily);
-  static const SolarIconsData dumbbellSmall =
-      SolarIconsData(0xea96, fontFamily: _fontFamily);
-  static const SolarIconsData dumbbell =
-      SolarIconsData(0xea97, fontFamily: _fontFamily);
-  static const SolarIconsData dumbbells2 =
-      SolarIconsData(0xea98, fontFamily: _fontFamily);
-  static const SolarIconsData dumbbells =
-      SolarIconsData(0xea99, fontFamily: _fontFamily);
-  static const SolarIconsData golf =
-      SolarIconsData(0xea9a, fontFamily: _fontFamily);
-  static const SolarIconsData hikingMinimalistic =
-      SolarIconsData(0xea9b, fontFamily: _fontFamily);
-  static const SolarIconsData hikingRound =
-      SolarIconsData(0xea9c, fontFamily: _fontFamily);
-  static const SolarIconsData hiking =
-      SolarIconsData(0xea9d, fontFamily: _fontFamily);
-  static const SolarIconsData meditationRound =
-      SolarIconsData(0xea9e, fontFamily: _fontFamily);
-  static const SolarIconsData meditation =
-      SolarIconsData(0xea9f, fontFamily: _fontFamily);
-  static const SolarIconsData ranking =
-      SolarIconsData(0xeaa0, fontFamily: _fontFamily);
-  static const SolarIconsData running_2 =
-      SolarIconsData(0xeaa1, fontFamily: _fontFamily);
-  static const SolarIconsData runningRound =
-      SolarIconsData(0xeaa2, fontFamily: _fontFamily);
-  static const SolarIconsData running =
-      SolarIconsData(0xeaa3, fontFamily: _fontFamily);
-  static const SolarIconsData stretchingRound =
-      SolarIconsData(0xeaa4, fontFamily: _fontFamily);
-  static const SolarIconsData stretching =
-      SolarIconsData(0xeaa5, fontFamily: _fontFamily);
-  static const SolarIconsData swimming =
-      SolarIconsData(0xeaa6, fontFamily: _fontFamily);
-  static const SolarIconsData treadmillRound =
-      SolarIconsData(0xeaa7, fontFamily: _fontFamily);
-  static const SolarIconsData treadmill =
-      SolarIconsData(0xeaa8, fontFamily: _fontFamily);
-  static const SolarIconsData walkingRound =
-      SolarIconsData(0xeaa9, fontFamily: _fontFamily);
-  static const SolarIconsData walking =
-      SolarIconsData(0xeaaa, fontFamily: _fontFamily);
-  static const SolarIconsData waterSun =
-      SolarIconsData(0xeaab, fontFamily: _fontFamily);
-  static const SolarIconsData water =
-      SolarIconsData(0xeaac, fontFamily: _fontFamily);
-  static const SolarIconsData bicyclingRound =
-      SolarIconsData(0xeaad, fontFamily: _fontFamily);
-  static const SolarIconsData bicycling =
-      SolarIconsData(0xeaae, fontFamily: _fontFamily);
-  static const SolarIconsData skateboard =
-      SolarIconsData(0xeaaf, fontFamily: _fontFamily);
-  static const SolarIconsData skateboardingRound =
-      SolarIconsData(0xeab0, fontFamily: _fontFamily);
-  static const SolarIconsData skateboarding =
-      SolarIconsData(0xeab1, fontFamily: _fontFamily);
-  static const SolarIconsData magnifierBug =
-      SolarIconsData(0xeab2, fontFamily: _fontFamily);
-  static const SolarIconsData magnifierZoomIn =
-      SolarIconsData(0xeab3, fontFamily: _fontFamily);
-  static const SolarIconsData magnifierZoomOut =
-      SolarIconsData(0xeab4, fontFamily: _fontFamily);
-  static const SolarIconsData magnifier =
-      SolarIconsData(0xeab5, fontFamily: _fontFamily);
-  static const SolarIconsData minimalisticMagnifierBug =
-      SolarIconsData(0xeab6, fontFamily: _fontFamily);
-  static const SolarIconsData minimalisticMagnifierZoomIn =
-      SolarIconsData(0xeab7, fontFamily: _fontFamily);
-  static const SolarIconsData minimalisticMagnifierZoomOut =
-      SolarIconsData(0xeab8, fontFamily: _fontFamily);
-  static const SolarIconsData minimalisticMagnifier =
-      SolarIconsData(0xeab9, fontFamily: _fontFamily);
-  static const SolarIconsData roundedMagnifierBug =
-      SolarIconsData(0xeaba, fontFamily: _fontFamily);
-  static const SolarIconsData roundedMagnifierZoomIn =
-      SolarIconsData(0xeabb, fontFamily: _fontFamily);
-  static const SolarIconsData roundedMagnifierZoomOut =
-      SolarIconsData(0xeabc, fontFamily: _fontFamily);
-  static const SolarIconsData roundedMagnifier =
-      SolarIconsData(0xeabd, fontFamily: _fontFamily);
-  static const SolarIconsData alarmAdd =
-      SolarIconsData(0xeabe, fontFamily: _fontFamily);
-  static const SolarIconsData alarmPause =
-      SolarIconsData(0xeabf, fontFamily: _fontFamily);
-  static const SolarIconsData alarmRemove =
-      SolarIconsData(0xeac0, fontFamily: _fontFamily);
-  static const SolarIconsData alarmTurnOff =
-      SolarIconsData(0xeac1, fontFamily: _fontFamily);
-  static const SolarIconsData calendarAdd =
-      SolarIconsData(0xeac2, fontFamily: _fontFamily);
-  static const SolarIconsData calendarDate =
-      SolarIconsData(0xeac3, fontFamily: _fontFamily);
-  static const SolarIconsData calendarMark =
-      SolarIconsData(0xeac4, fontFamily: _fontFamily);
-  static const SolarIconsData calendarMinimalistic =
-      SolarIconsData(0xeac5, fontFamily: _fontFamily);
-  static const SolarIconsData calendarSearch =
-      SolarIconsData(0xeac6, fontFamily: _fontFamily);
-  static const SolarIconsData calendar =
-      SolarIconsData(0xeac7, fontFamily: _fontFamily);
-  static const SolarIconsData history_2 =
-      SolarIconsData(0xeac8, fontFamily: _fontFamily);
-  static const SolarIconsData history3 =
-      SolarIconsData(0xeac9, fontFamily: _fontFamily);
-  static const SolarIconsData hourglassLine =
-      SolarIconsData(0xeaca, fontFamily: _fontFamily);
-  static const SolarIconsData hourglass =
-      SolarIconsData(0xeacb, fontFamily: _fontFamily);
-  static const SolarIconsData stopwatchPause =
-      SolarIconsData(0xeacc, fontFamily: _fontFamily);
-  static const SolarIconsData stopwatchPlay =
-      SolarIconsData(0xeacd, fontFamily: _fontFamily);
-  static const SolarIconsData stopwatch =
-      SolarIconsData(0xeace, fontFamily: _fontFamily);
-  static const SolarIconsData watchRound =
-      SolarIconsData(0xeacf, fontFamily: _fontFamily);
-  static const SolarIconsData watchSquareMinimalisticCharge =
-      SolarIconsData(0xead0, fontFamily: _fontFamily);
-  static const SolarIconsData watchSquareMinimalistic =
-      SolarIconsData(0xead1, fontFamily: _fontFamily);
-  static const SolarIconsData watchSquare =
-      SolarIconsData(0xead2, fontFamily: _fontFamily);
-  static const SolarIconsData alarmPlay =
-      SolarIconsData(0xead3, fontFamily: _fontFamily);
-  static const SolarIconsData alarmSleep =
-      SolarIconsData(0xead4, fontFamily: _fontFamily);
-  static const SolarIconsData alarm =
-      SolarIconsData(0xead5, fontFamily: _fontFamily);
-  static const SolarIconsData clockCircle =
-      SolarIconsData(0xead6, fontFamily: _fontFamily);
-  static const SolarIconsData clockSquare =
-      SolarIconsData(0xead7, fontFamily: _fontFamily);
-  static const SolarIconsData history =
-      SolarIconsData(0xead8, fontFamily: _fontFamily);
-  static const SolarIconsData listArrowDown =
-      SolarIconsData(0xead9, fontFamily: _fontFamily);
-  static const SolarIconsData listArrowUpMinimalistic =
-      SolarIconsData(0xeada, fontFamily: _fontFamily);
-  static const SolarIconsData listArrowUp =
-      SolarIconsData(0xeadb, fontFamily: _fontFamily);
-  static const SolarIconsData listCheckMinimalistic =
-      SolarIconsData(0xeadc, fontFamily: _fontFamily);
-  static const SolarIconsData listCheck =
-      SolarIconsData(0xeadd, fontFamily: _fontFamily);
-  static const SolarIconsData listCrossMinimalistic =
-      SolarIconsData(0xeade, fontFamily: _fontFamily);
-  static const SolarIconsData listCross =
-      SolarIconsData(0xeadf, fontFamily: _fontFamily);
-  static const SolarIconsData listDown =
-      SolarIconsData(0xeae0, fontFamily: _fontFamily);
-  static const SolarIconsData listUpMinimalistic =
-      SolarIconsData(0xeae1, fontFamily: _fontFamily);
-  static const SolarIconsData listUp =
-      SolarIconsData(0xeae2, fontFamily: _fontFamily);
-  static const SolarIconsData list =
-      SolarIconsData(0xeae3, fontFamily: _fontFamily);
-  static const SolarIconsData list_1 =
-      SolarIconsData(0xeae4, fontFamily: _fontFamily);
-  static const SolarIconsData playlist =
-      SolarIconsData(0xeae5, fontFamily: _fontFamily);
-  static const SolarIconsData sortByAlphabet =
-      SolarIconsData(0xeae6, fontFamily: _fontFamily);
-  static const SolarIconsData sortByTime =
-      SolarIconsData(0xeae7, fontFamily: _fontFamily);
-  static const SolarIconsData sortFromBottomToTop =
-      SolarIconsData(0xeae8, fontFamily: _fontFamily);
-  static const SolarIconsData sortFromTopToBottom =
-      SolarIconsData(0xeae9, fontFamily: _fontFamily);
-  static const SolarIconsData listDownMinimalistic =
-      SolarIconsData(0xeaea, fontFamily: _fontFamily);
-  static const SolarIconsData listHeartMinimalistic =
-      SolarIconsData(0xeaeb, fontFamily: _fontFamily);
-  static const SolarIconsData listHeart =
-      SolarIconsData(0xeaec, fontFamily: _fontFamily);
-  static const SolarIconsData playlistMinimalistic =
-      SolarIconsData(0xeaed, fontFamily: _fontFamily);
-  static const SolarIconsData playlist_2 =
-      SolarIconsData(0xeaee, fontFamily: _fontFamily);
-  static const SolarIconsData playlistMinimalistic2 =
-      SolarIconsData(0xeaef, fontFamily: _fontFamily);
-  static const SolarIconsData playlistMinimalistic3 =
-      SolarIconsData(0xeaf0, fontFamily: _fontFamily);
-  static const SolarIconsData bill1 =
-      SolarIconsData(0xeaf1, fontFamily: _fontFamily);
-  static const SolarIconsData checklistMinimalistic =
-      SolarIconsData(0xeaf2, fontFamily: _fontFamily);
-  static const SolarIconsData checklist =
-      SolarIconsData(0xeaf3, fontFamily: _fontFamily);
-  static const SolarIconsData listArrowDownMinimalistic =
-      SolarIconsData(0xeaf4, fontFamily: _fontFamily);
-  static const SolarIconsData callDroppedRounded =
-      SolarIconsData(0xeaf5, fontFamily: _fontFamily);
-  static const SolarIconsData endCallRounded =
-      SolarIconsData(0xeaf6, fontFamily: _fontFamily);
-  static const SolarIconsData incomingCallRounded =
-      SolarIconsData(0xeaf7, fontFamily: _fontFamily);
-  static const SolarIconsData outgoingCallRounded =
-      SolarIconsData(0xeaf8, fontFamily: _fontFamily);
-  static const SolarIconsData phoneCallingRounded =
-      SolarIconsData(0xeaf9, fontFamily: _fontFamily);
-  static const SolarIconsData phoneRounded =
-      SolarIconsData(0xeafa, fontFamily: _fontFamily);
-  static const SolarIconsData callCancel =
-      SolarIconsData(0xeafb, fontFamily: _fontFamily);
-  static const SolarIconsData callChatRounded =
-      SolarIconsData(0xeafc, fontFamily: _fontFamily);
-  static const SolarIconsData callChat =
-      SolarIconsData(0xeafd, fontFamily: _fontFamily);
-  static const SolarIconsData callDropped =
-      SolarIconsData(0xeafe, fontFamily: _fontFamily);
-  static const SolarIconsData callMedicineRounded =
-      SolarIconsData(0xeaff, fontFamily: _fontFamily);
-  static const SolarIconsData callMedicine =
-      SolarIconsData(0xeb00, fontFamily: _fontFamily);
-  static const SolarIconsData endCall =
-      SolarIconsData(0xeb01, fontFamily: _fontFamily);
-  static const SolarIconsData incomingCall =
-      SolarIconsData(0xeb02, fontFamily: _fontFamily);
-  static const SolarIconsData outgoingCall =
-      SolarIconsData(0xeb03, fontFamily: _fontFamily);
-  static const SolarIconsData phoneCalling =
-      SolarIconsData(0xeb04, fontFamily: _fontFamily);
-  static const SolarIconsData phone =
-      SolarIconsData(0xeb05, fontFamily: _fontFamily);
-  static const SolarIconsData recordCircle =
-      SolarIconsData(0xeb06, fontFamily: _fontFamily);
-  static const SolarIconsData recordMinimalistic =
-      SolarIconsData(0xeb07, fontFamily: _fontFamily);
-  static const SolarIconsData recordSquare =
-      SolarIconsData(0xeb08, fontFamily: _fontFamily);
-  static const SolarIconsData callCancelRounded =
-      SolarIconsData(0xeb09, fontFamily: _fontFamily);
-  static const SolarIconsData pills_2 =
-      SolarIconsData(0xeb0a, fontFamily: _fontFamily);
-  static const SolarIconsData pills_3 =
-      SolarIconsData(0xeb0b, fontFamily: _fontFamily);
-  static const SolarIconsData stethoscope =
-      SolarIconsData(0xeb0c, fontFamily: _fontFamily);
-  static const SolarIconsData syringe =
-      SolarIconsData(0xeb0d, fontFamily: _fontFamily);
-  static const SolarIconsData thermometer =
-      SolarIconsData(0xeb0e, fontFamily: _fontFamily);
-  static const SolarIconsData adhesivePlaster2 =
-      SolarIconsData(0xeb0f, fontFamily: _fontFamily);
-  static const SolarIconsData adhesivePlaster =
-      SolarIconsData(0xeb10, fontFamily: _fontFamily);
-  static const SolarIconsData boneBroken =
-      SolarIconsData(0xeb11, fontFamily: _fontFamily);
-  static const SolarIconsData boneCrack =
-      SolarIconsData(0xeb12, fontFamily: _fontFamily);
-  static const SolarIconsData bone =
-      SolarIconsData(0xeb13, fontFamily: _fontFamily);
-  static const SolarIconsData bones =
-      SolarIconsData(0xeb14, fontFamily: _fontFamily);
-  static const SolarIconsData dropper_3 =
-      SolarIconsData(0xeb15, fontFamily: _fontFamily);
-  static const SolarIconsData dropperMinimalistic2 =
-      SolarIconsData(0xeb16, fontFamily: _fontFamily);
-  static const SolarIconsData dropperMinimalistic =
-      SolarIconsData(0xeb17, fontFamily: _fontFamily);
-  static const SolarIconsData health =
-      SolarIconsData(0xeb18, fontFamily: _fontFamily);
-  static const SolarIconsData heartPulse2 =
-      SolarIconsData(0xeb19, fontFamily: _fontFamily);
-  static const SolarIconsData heartPulse =
-      SolarIconsData(0xeb1a, fontFamily: _fontFamily);
-  static const SolarIconsData medicalKit =
-      SolarIconsData(0xeb1b, fontFamily: _fontFamily);
-  static const SolarIconsData pill =
-      SolarIconsData(0xeb1c, fontFamily: _fontFamily);
-  static const SolarIconsData pills =
-      SolarIconsData(0xeb1d, fontFamily: _fontFamily);
-  static const SolarIconsData pulse_2 =
-      SolarIconsData(0xeb1e, fontFamily: _fontFamily);
-  static const SolarIconsData pulse =
-      SolarIconsData(0xeb1f, fontFamily: _fontFamily);
-  static const SolarIconsData testTubeMinimalistic =
-      SolarIconsData(0xeb20, fontFamily: _fontFamily);
-  static const SolarIconsData testTube =
-      SolarIconsData(0xeb21, fontFamily: _fontFamily);
-  static const SolarIconsData virus =
-      SolarIconsData(0xeb22, fontFamily: _fontFamily);
-  static const SolarIconsData bacteria =
-      SolarIconsData(0xeb23, fontFamily: _fontFamily);
-  static const SolarIconsData benzeneRing =
-      SolarIconsData(0xeb24, fontFamily: _fontFamily);
-  static const SolarIconsData dna =
-      SolarIconsData(0xeb25, fontFamily: _fontFamily);
-  static const SolarIconsData dropper_2 =
-      SolarIconsData(0xeb26, fontFamily: _fontFamily);
-  static const SolarIconsData dropper =
-      SolarIconsData(0xeb27, fontFamily: _fontFamily);
-  static const SolarIconsData jarOfPills2 =
-      SolarIconsData(0xeb28, fontFamily: _fontFamily);
-  static const SolarIconsData jarOfPills =
-      SolarIconsData(0xeb29, fontFamily: _fontFamily);
-  static const SolarIconsData washingMachine =
-      SolarIconsData(0xeb2a, fontFamily: _fontFamily);
-  static const SolarIconsData conditioner_2 =
-      SolarIconsData(0xeb2b, fontFamily: _fontFamily);
-  static const SolarIconsData conditioner =
-      SolarIconsData(0xeb2c, fontFamily: _fontFamily);
-  static const SolarIconsData remoteController2 =
-      SolarIconsData(0xeb2d, fontFamily: _fontFamily);
-  static const SolarIconsData remoteControllerMinimalistic =
-      SolarIconsData(0xeb2e, fontFamily: _fontFamily);
-  static const SolarIconsData remoteController =
-      SolarIconsData(0xeb2f, fontFamily: _fontFamily);
-  static const SolarIconsData speakerMinimalistic =
-      SolarIconsData(0xeb30, fontFamily: _fontFamily);
-  static const SolarIconsData speaker =
-      SolarIconsData(0xeb31, fontFamily: _fontFamily);
-  static const SolarIconsData volumeKnob =
-      SolarIconsData(0xeb32, fontFamily: _fontFamily);
-  static const SolarIconsData armchair_2 =
-      SolarIconsData(0xeb33, fontFamily: _fontFamily);
-  static const SolarIconsData armchair =
-      SolarIconsData(0xeb34, fontFamily: _fontFamily);
-  static const SolarIconsData barChair =
-      SolarIconsData(0xeb35, fontFamily: _fontFamily);
-  static const SolarIconsData bath =
-      SolarIconsData(0xeb36, fontFamily: _fontFamily);
-  static const SolarIconsData bed =
-      SolarIconsData(0xeb37, fontFamily: _fontFamily);
-  static const SolarIconsData bedsideTable2 =
-      SolarIconsData(0xeb38, fontFamily: _fontFamily);
-  static const SolarIconsData bedsideTable3 =
-      SolarIconsData(0xeb39, fontFamily: _fontFamily);
-  static const SolarIconsData bedsideTable4 =
-      SolarIconsData(0xeb3a, fontFamily: _fontFamily);
-  static const SolarIconsData bedsideTable =
-      SolarIconsData(0xeb3b, fontFamily: _fontFamily);
-  static const SolarIconsData chair_2 =
-      SolarIconsData(0xeb3c, fontFamily: _fontFamily);
-  static const SolarIconsData chair =
-      SolarIconsData(0xeb3d, fontFamily: _fontFamily);
-  static const SolarIconsData chandelier =
-      SolarIconsData(0xeb3e, fontFamily: _fontFamily);
-  static const SolarIconsData closet_2 =
-      SolarIconsData(0xeb3f, fontFamily: _fontFamily);
-  static const SolarIconsData closet =
-      SolarIconsData(0xeb40, fontFamily: _fontFamily);
-  static const SolarIconsData floorLampMinimalistic =
-      SolarIconsData(0xeb41, fontFamily: _fontFamily);
-  static const SolarIconsData floorLamp =
-      SolarIconsData(0xeb42, fontFamily: _fontFamily);
-  static const SolarIconsData fridge =
-      SolarIconsData(0xeb43, fontFamily: _fontFamily);
-  static const SolarIconsData lamp =
-      SolarIconsData(0xeb44, fontFamily: _fontFamily);
-  static const SolarIconsData mirror =
-      SolarIconsData(0xeb45, fontFamily: _fontFamily);
-  static const SolarIconsData smartVacuumCleaner_2 =
-      SolarIconsData(0xeb46, fontFamily: _fontFamily);
-  static const SolarIconsData smartVacuumCleaner =
-      SolarIconsData(0xeb47, fontFamily: _fontFamily);
-  static const SolarIconsData sofa_2 =
-      SolarIconsData(0xeb48, fontFamily: _fontFamily);
-  static const SolarIconsData sofa_3 =
-      SolarIconsData(0xeb49, fontFamily: _fontFamily);
-  static const SolarIconsData sofa =
-      SolarIconsData(0xeb4a, fontFamily: _fontFamily);
-  static const SolarIconsData trellis =
-      SolarIconsData(0xeb4b, fontFamily: _fontFamily);
-  static const SolarIconsData washingMachineMinimalistic =
-      SolarIconsData(0xeb4c, fontFamily: _fontFamily);
-  static const SolarIconsData tuning =
-      SolarIconsData(0xeb4d, fontFamily: _fontFamily);
-  static const SolarIconsData widget_2 =
-      SolarIconsData(0xeb4e, fontFamily: _fontFamily);
-  static const SolarIconsData widget_3 =
-      SolarIconsData(0xeb4f, fontFamily: _fontFamily);
-  static const SolarIconsData widget_4 =
-      SolarIconsData(0xeb50, fontFamily: _fontFamily);
-  static const SolarIconsData widget_5 =
-      SolarIconsData(0xeb51, fontFamily: _fontFamily);
-  static const SolarIconsData widget_6 =
-      SolarIconsData(0xeb52, fontFamily: _fontFamily);
-  static const SolarIconsData widgetAdd =
-      SolarIconsData(0xeb53, fontFamily: _fontFamily);
-  static const SolarIconsData widget =
-      SolarIconsData(0xeb54, fontFamily: _fontFamily);
-  static const SolarIconsData settingsMinimalistic =
-      SolarIconsData(0xeb55, fontFamily: _fontFamily);
-  static const SolarIconsData settings =
-      SolarIconsData(0xeb56, fontFamily: _fontFamily);
-  static const SolarIconsData tuning_2 =
-      SolarIconsData(0xeb57, fontFamily: _fontFamily);
-  static const SolarIconsData tuning_3 =
-      SolarIconsData(0xeb58, fontFamily: _fontFamily);
-  static const SolarIconsData tuning_4 =
-      SolarIconsData(0xeb59, fontFamily: _fontFamily);
-  static const SolarIconsData tuningSquare_2 =
-      SolarIconsData(0xeb5a, fontFamily: _fontFamily);
-  static const SolarIconsData tuningSquare =
-      SolarIconsData(0xeb5b, fontFamily: _fontFamily);
-  static const SolarIconsData usbSquare =
-      SolarIconsData(0xeb5c, fontFamily: _fontFamily);
-  static const SolarIconsData usb =
-      SolarIconsData(0xeb5d, fontFamily: _fontFamily);
-  static const SolarIconsData wifiRouterMinimalistic =
-      SolarIconsData(0xeb5e, fontFamily: _fontFamily);
-  static const SolarIconsData wifiRouterRound =
-      SolarIconsData(0xeb5f, fontFamily: _fontFamily);
-  static const SolarIconsData wifiRouter =
-      SolarIconsData(0xeb60, fontFamily: _fontFamily);
-  static const SolarIconsData windowFrame =
-      SolarIconsData(0xeb61, fontFamily: _fontFamily);
-  static const SolarIconsData bugMinimalistic =
-      SolarIconsData(0xeb62, fontFamily: _fontFamily);
-  static const SolarIconsData bug =
-      SolarIconsData(0xeb63, fontFamily: _fontFamily);
-  static const SolarIconsData command =
-      SolarIconsData(0xeb64, fontFamily: _fontFamily);
-  static const SolarIconsData hashtagChat =
-      SolarIconsData(0xeb65, fontFamily: _fontFamily);
-  static const SolarIconsData hashtagCircle =
-      SolarIconsData(0xeb66, fontFamily: _fontFamily);
-  static const SolarIconsData hashtagSquare =
-      SolarIconsData(0xeb67, fontFamily: _fontFamily);
-  static const SolarIconsData hashtag =
-      SolarIconsData(0xeb68, fontFamily: _fontFamily);
-  static const SolarIconsData structure =
-      SolarIconsData(0xeb69, fontFamily: _fontFamily);
-  static const SolarIconsData code2 =
-      SolarIconsData(0xeb6a, fontFamily: _fontFamily);
-  static const SolarIconsData codeCircle =
-      SolarIconsData(0xeb6b, fontFamily: _fontFamily);
-  static const SolarIconsData codeSquare =
-      SolarIconsData(0xeb6c, fontFamily: _fontFamily);
-  static const SolarIconsData code =
-      SolarIconsData(0xeb6d, fontFamily: _fontFamily);
-  static const SolarIconsData programming =
-      SolarIconsData(0xeb6e, fontFamily: _fontFamily);
-  static const SolarIconsData screencast_2 =
-      SolarIconsData(0xeb6f, fontFamily: _fontFamily);
-  static const SolarIconsData screencast =
-      SolarIconsData(0xeb70, fontFamily: _fontFamily);
-  static const SolarIconsData sidebarCode =
-      SolarIconsData(0xeb71, fontFamily: _fontFamily);
-  static const SolarIconsData sidebarMinimalistic =
-      SolarIconsData(0xeb72, fontFamily: _fontFamily);
-  static const SolarIconsData sidebar =
-      SolarIconsData(0xeb73, fontFamily: _fontFamily);
-  static const SolarIconsData slashCircle =
-      SolarIconsData(0xeb74, fontFamily: _fontFamily);
-  static const SolarIconsData slashSquare =
-      SolarIconsData(0xeb75, fontFamily: _fontFamily);
-  static const SolarIconsData stationMinimalistic =
-      SolarIconsData(0xeb76, fontFamily: _fontFamily);
-  static const SolarIconsData station =
-      SolarIconsData(0xeb77, fontFamily: _fontFamily);
-  static const SolarIconsData translation_2 =
-      SolarIconsData(0xeb78, fontFamily: _fontFamily);
-  static const SolarIconsData translation =
-      SolarIconsData(0xeb79, fontFamily: _fontFamily);
-  static const SolarIconsData usbCircle =
-      SolarIconsData(0xeb7a, fontFamily: _fontFamily);
-  static const SolarIconsData textUnderline =
-      SolarIconsData(0xeb7b, fontFamily: _fontFamily);
-  static const SolarIconsData text =
-      SolarIconsData(0xeb7c, fontFamily: _fontFamily);
-  static const SolarIconsData eraserCircle =
-      SolarIconsData(0xeb7d, fontFamily: _fontFamily);
-  static const SolarIconsData eraserSquare =
-      SolarIconsData(0xeb7e, fontFamily: _fontFamily);
-  static const SolarIconsData eraser =
-      SolarIconsData(0xeb7f, fontFamily: _fontFamily);
-  static const SolarIconsData textItalicSquare =
-      SolarIconsData(0xeb80, fontFamily: _fontFamily);
-  static const SolarIconsData textItalic =
-      SolarIconsData(0xeb81, fontFamily: _fontFamily);
-  static const SolarIconsData textFieldFocus =
-      SolarIconsData(0xeb82, fontFamily: _fontFamily);
-  static const SolarIconsData backspace =
-      SolarIconsData(0xeb83, fontFamily: _fontFamily);
-  static const SolarIconsData linkBrokenMinimalistic =
-      SolarIconsData(0xeb84, fontFamily: _fontFamily);
-  static const SolarIconsData linkBroken =
-      SolarIconsData(0xeb85, fontFamily: _fontFamily);
-  static const SolarIconsData linkCircle =
-      SolarIconsData(0xeb86, fontFamily: _fontFamily);
-  static const SolarIconsData linkMinimalistic_2 =
-      SolarIconsData(0xeb87, fontFamily: _fontFamily);
-  static const SolarIconsData linkMinimalistic =
-      SolarIconsData(0xeb88, fontFamily: _fontFamily);
-  static const SolarIconsData linkRoundAngle =
-      SolarIconsData(0xeb89, fontFamily: _fontFamily);
-  static const SolarIconsData linkRound =
-      SolarIconsData(0xeb8a, fontFamily: _fontFamily);
-  static const SolarIconsData linkSquare =
-      SolarIconsData(0xeb8b, fontFamily: _fontFamily);
-  static const SolarIconsData link =
-      SolarIconsData(0xeb8c, fontFamily: _fontFamily);
-  static const SolarIconsData paragraphSpacing =
-      SolarIconsData(0xeb8d, fontFamily: _fontFamily);
-  static const SolarIconsData textBoldCircle =
-      SolarIconsData(0xeb8e, fontFamily: _fontFamily);
-  static const SolarIconsData textBoldSquare =
-      SolarIconsData(0xeb8f, fontFamily: _fontFamily);
-  static const SolarIconsData textBold =
-      SolarIconsData(0xeb90, fontFamily: _fontFamily);
-  static const SolarIconsData textCircle =
-      SolarIconsData(0xeb91, fontFamily: _fontFamily);
-  static const SolarIconsData textCrossCircle =
-      SolarIconsData(0xeb92, fontFamily: _fontFamily);
-  static const SolarIconsData textCrossSquare =
-      SolarIconsData(0xeb93, fontFamily: _fontFamily);
-  static const SolarIconsData textCross =
-      SolarIconsData(0xeb94, fontFamily: _fontFamily);
-  static const SolarIconsData textField =
-      SolarIconsData(0xeb95, fontFamily: _fontFamily);
-  static const SolarIconsData textItalicCircle =
-      SolarIconsData(0xeb96, fontFamily: _fontFamily);
-  static const SolarIconsData textSelection =
-      SolarIconsData(0xeb97, fontFamily: _fontFamily);
-  static const SolarIconsData textSquare2 =
-      SolarIconsData(0xeb98, fontFamily: _fontFamily);
-  static const SolarIconsData textSquare =
-      SolarIconsData(0xeb99, fontFamily: _fontFamily);
-  static const SolarIconsData textUnderlineCircle =
-      SolarIconsData(0xeb9a, fontFamily: _fontFamily);
-  static const SolarIconsData textUnderlineCross =
-      SolarIconsData(0xeb9b, fontFamily: _fontFamily);
-  static const SolarIconsData graph =
-      SolarIconsData(0xeb9c, fontFamily: _fontFamily);
-  static const SolarIconsData pieChart2 =
-      SolarIconsData(0xeb9d, fontFamily: _fontFamily);
-  static const SolarIconsData pieChart3 =
-      SolarIconsData(0xeb9e, fontFamily: _fontFamily);
-  static const SolarIconsData pieChart =
-      SolarIconsData(0xeb9f, fontFamily: _fontFamily);
-  static const SolarIconsData presentationGraph =
-      SolarIconsData(0xeba0, fontFamily: _fontFamily);
-  static const SolarIconsData roundGraph =
-      SolarIconsData(0xeba1, fontFamily: _fontFamily);
-  static const SolarIconsData chart_2 =
-      SolarIconsData(0xeba2, fontFamily: _fontFamily);
-  static const SolarIconsData chartSquare =
-      SolarIconsData(0xeba3, fontFamily: _fontFamily);
-  static const SolarIconsData chart =
-      SolarIconsData(0xeba4, fontFamily: _fontFamily);
-  static const SolarIconsData chatSquare_2 =
-      SolarIconsData(0xeba5, fontFamily: _fontFamily);
-  static const SolarIconsData courseDown =
-      SolarIconsData(0xeba6, fontFamily: _fontFamily);
-  static const SolarIconsData courseUp =
-      SolarIconsData(0xeba7, fontFamily: _fontFamily);
-  static const SolarIconsData diagramDown =
-      SolarIconsData(0xeba8, fontFamily: _fontFamily);
-  static const SolarIconsData diagramUp =
-      SolarIconsData(0xeba9, fontFamily: _fontFamily);
-  static const SolarIconsData graphDownNew =
-      SolarIconsData(0xebaa, fontFamily: _fontFamily);
-  static const SolarIconsData graphDown =
-      SolarIconsData(0xebab, fontFamily: _fontFamily);
-  static const SolarIconsData graphNewUp =
-      SolarIconsData(0xebac, fontFamily: _fontFamily);
-  static const SolarIconsData graphNew =
-      SolarIconsData(0xebad, fontFamily: _fontFamily);
-  static const SolarIconsData graphUp =
-      SolarIconsData(0xebae, fontFamily: _fontFamily);
-  static const SolarIconsData shopMinimalistic =
-      SolarIconsData(0xebaf, fontFamily: _fontFamily);
-  static const SolarIconsData shop =
-      SolarIconsData(0xebb0, fontFamily: _fontFamily);
-  static const SolarIconsData cartCheck =
-      SolarIconsData(0xebb1, fontFamily: _fontFamily);
-  static const SolarIconsData cartCross =
-      SolarIconsData(0xebb2, fontFamily: _fontFamily);
-  static const SolarIconsData cartLarge2 =
-      SolarIconsData(0xebb3, fontFamily: _fontFamily);
-  static const SolarIconsData cartLarge3 =
-      SolarIconsData(0xebb4, fontFamily: _fontFamily);
-  static const SolarIconsData cartLargeMinimalistic =
-      SolarIconsData(0xebb5, fontFamily: _fontFamily);
-  static const SolarIconsData cartLarge =
-      SolarIconsData(0xebb6, fontFamily: _fontFamily);
-  static const SolarIconsData cartPlus =
-      SolarIconsData(0xebb7, fontFamily: _fontFamily);
-  static const SolarIconsData bag2 =
-      SolarIconsData(0xebb8, fontFamily: _fontFamily);
-  static const SolarIconsData bag3 =
-      SolarIconsData(0xebb9, fontFamily: _fontFamily);
-  static const SolarIconsData bag4 =
-      SolarIconsData(0xebba, fontFamily: _fontFamily);
-  static const SolarIconsData bag5 =
-      SolarIconsData(0xebbb, fontFamily: _fontFamily);
-  static const SolarIconsData bagCheck =
-      SolarIconsData(0xebbc, fontFamily: _fontFamily);
-  static const SolarIconsData bagCross =
-      SolarIconsData(0xebbd, fontFamily: _fontFamily);
-  static const SolarIconsData bagHeart =
-      SolarIconsData(0xebbe, fontFamily: _fontFamily);
-  static const SolarIconsData bagMusic_2 =
-      SolarIconsData(0xebbf, fontFamily: _fontFamily);
-  static const SolarIconsData bagMusic =
-      SolarIconsData(0xebc0, fontFamily: _fontFamily);
-  static const SolarIconsData bagSmile =
-      SolarIconsData(0xebc1, fontFamily: _fontFamily);
-  static const SolarIconsData bag =
-      SolarIconsData(0xebc2, fontFamily: _fontFamily);
-  static const SolarIconsData cart_2 =
-      SolarIconsData(0xebc3, fontFamily: _fontFamily);
-  static const SolarIconsData cart_3 =
-      SolarIconsData(0xebc4, fontFamily: _fontFamily);
-  static const SolarIconsData cart_4 =
-      SolarIconsData(0xebc5, fontFamily: _fontFamily);
-  static const SolarIconsData cart_5 =
-      SolarIconsData(0xebc6, fontFamily: _fontFamily);
-  static const SolarIconsData cartLarge_4 =
-      SolarIconsData(0xebc7, fontFamily: _fontFamily);
-  static const SolarIconsData cart =
-      SolarIconsData(0xebc8, fontFamily: _fontFamily);
-  static const SolarIconsData shop_2 =
-      SolarIconsData(0xebc9, fontFamily: _fontFamily);
-  static const SolarIconsData fire =
-      SolarIconsData(0xebca, fontFamily: _fontFamily);
-  static const SolarIconsData flame =
-      SolarIconsData(0xebcb, fontFamily: _fontFamily);
-  static const SolarIconsData leaf =
-      SolarIconsData(0xebcc, fontFamily: _fontFamily);
-  static const SolarIconsData suitcaseLines =
-      SolarIconsData(0xebcd, fontFamily: _fontFamily);
-  static const SolarIconsData suitcaseTag =
-      SolarIconsData(0xebce, fontFamily: _fontFamily);
-  static const SolarIconsData suitcase =
-      SolarIconsData(0xebcf, fontFamily: _fontFamily);
-  static const SolarIconsData bonfire =
-      SolarIconsData(0xebd0, fontFamily: _fontFamily);
-  static const SolarIconsData fireMinimalistic =
-      SolarIconsData(0xebd1, fontFamily: _fontFamily);
-  static const SolarIconsData fireSquare =
-      SolarIconsData(0xebd2, fontFamily: _fontFamily);
-  static const SolarIconsData diploma =
-      SolarIconsData(0xebd3, fontFamily: _fontFamily);
-  static const SolarIconsData notebookBookmark =
-      SolarIconsData(0xebd4, fontFamily: _fontFamily);
-  static const SolarIconsData notebookMinimalistic =
-      SolarIconsData(0xebd5, fontFamily: _fontFamily);
-  static const SolarIconsData notebookSquare =
-      SolarIconsData(0xebd6, fontFamily: _fontFamily);
-  static const SolarIconsData notebook =
-      SolarIconsData(0xebd7, fontFamily: _fontFamily);
-  static const SolarIconsData plus =
-      SolarIconsData(0xebd8, fontFamily: _fontFamily);
-  static const SolarIconsData minus =
-      SolarIconsData(0xebd8, fontFamily: _fontFamily);
-  static const SolarIconsData squareAcademicCap2 =
-      SolarIconsData(0xebd9, fontFamily: _fontFamily);
-  static const SolarIconsData squareAcademicCap =
-      SolarIconsData(0xebda, fontFamily: _fontFamily);
-  static const SolarIconsData bookmarkCircle =
-      SolarIconsData(0xebdb, fontFamily: _fontFamily);
-  static const SolarIconsData bookmarkOpened =
-      SolarIconsData(0xebdc, fontFamily: _fontFamily);
-  static const SolarIconsData bookmarkSquareMinimalistic =
-      SolarIconsData(0xebdd, fontFamily: _fontFamily);
-  static const SolarIconsData bookmarkSquare =
-      SolarIconsData(0xebde, fontFamily: _fontFamily);
-  static const SolarIconsData bookmark =
-      SolarIconsData(0xebdf, fontFamily: _fontFamily);
-  static const SolarIconsData document =
-      SolarIconsData(0xebe0, fontFamily: _fontFamily);
-  static const SolarIconsData passportMinimalistic =
-      SolarIconsData(0xebe1, fontFamily: _fontFamily);
-  static const SolarIconsData passport =
-      SolarIconsData(0xebe2, fontFamily: _fontFamily);
-  static const SolarIconsData backpack =
-      SolarIconsData(0xebe3, fontFamily: _fontFamily);
-  static const SolarIconsData book2 =
-      SolarIconsData(0xebe4, fontFamily: _fontFamily);
-  static const SolarIconsData bookBookmarkMinimalistic =
-      SolarIconsData(0xebe5, fontFamily: _fontFamily);
-  static const SolarIconsData bookBookmark =
-      SolarIconsData(0xebe6, fontFamily: _fontFamily);
-  static const SolarIconsData bookMinimalistic =
-      SolarIconsData(0xebe7, fontFamily: _fontFamily);
-  static const SolarIconsData book =
-      SolarIconsData(0xebe8, fontFamily: _fontFamily);
-  static const SolarIconsData calculatorMinimalistic =
-      SolarIconsData(0xebe9, fontFamily: _fontFamily);
-  static const SolarIconsData calculator =
-      SolarIconsData(0xebea, fontFamily: _fontFamily);
-  static const SolarIconsData caseMinimalistic =
-      SolarIconsData(0xebeb, fontFamily: _fontFamily);
-  static const SolarIconsData caseRoundMinimalistic =
-      SolarIconsData(0xebec, fontFamily: _fontFamily);
-  static const SolarIconsData caseRound =
-      SolarIconsData(0xebed, fontFamily: _fontFamily);
-  static const SolarIconsData case_ =
-      SolarIconsData(0xebee, fontFamily: _fontFamily);
-  static const SolarIconsData diplomaVerified =
-      SolarIconsData(0xebef, fontFamily: _fontFamily);
-  static const SolarIconsData mirrorRight =
-      SolarIconsData(0xebf0, fontFamily: _fontFamily);
-  static const SolarIconsData pipette =
-      SolarIconsData(0xebf1, fontFamily: _fontFamily);
-  static const SolarIconsData radialBlur =
-      SolarIconsData(0xebf2, fontFamily: _fontFamily);
-  static const SolarIconsData rulerAngular =
-      SolarIconsData(0xebf3, fontFamily: _fontFamily);
-  static const SolarIconsData rulerCrossPen =
-      SolarIconsData(0xebf4, fontFamily: _fontFamily);
-  static const SolarIconsData rulerPen =
-      SolarIconsData(0xebf5, fontFamily: _fontFamily);
-  static const SolarIconsData ruler =
-      SolarIconsData(0xebf6, fontFamily: _fontFamily);
-  static const SolarIconsData threeSquares =
-      SolarIconsData(0xebf7, fontFamily: _fontFamily);
-  static const SolarIconsData alignBottom =
-      SolarIconsData(0xebf8, fontFamily: _fontFamily);
-  static const SolarIconsData alignHorizontalSpacing =
-      SolarIconsData(0xebf9, fontFamily: _fontFamily);
-  static const SolarIconsData alignHorizontalCenter =
-      SolarIconsData(0xebfa, fontFamily: _fontFamily);
-  static const SolarIconsData alignLeft =
-      SolarIconsData(0xebfb, fontFamily: _fontFamily);
-  static const SolarIconsData alignRight =
-      SolarIconsData(0xebfc, fontFamily: _fontFamily);
-  static const SolarIconsData alignTop =
-      SolarIconsData(0xebfd, fontFamily: _fontFamily);
-  static const SolarIconsData alignVerticalCenter =
-      SolarIconsData(0xebfe, fontFamily: _fontFamily);
-  static const SolarIconsData alignVerticalSpacing =
-      SolarIconsData(0xebff, fontFamily: _fontFamily);
-  static const SolarIconsData layersMinimalistic =
-      SolarIconsData(0xec00, fontFamily: _fontFamily);
-  static const SolarIconsData layers =
-      SolarIconsData(0xec01, fontFamily: _fontFamily);
-  static const SolarIconsData paintRoller =
-      SolarIconsData(0xec02, fontFamily: _fontFamily);
-  static const SolarIconsData paletteRound =
-      SolarIconsData(0xec03, fontFamily: _fontFamily);
-  static const SolarIconsData palette =
-      SolarIconsData(0xec04, fontFamily: _fontFamily);
-  static const SolarIconsData palette2 =
-      SolarIconsData(0xec05, fontFamily: _fontFamily);
-  static const SolarIconsData colourTuning =
-      SolarIconsData(0xec06, fontFamily: _fontFamily);
-  static const SolarIconsData cropMinimalistic =
-      SolarIconsData(0xec07, fontFamily: _fontFamily);
-  static const SolarIconsData crop =
-      SolarIconsData(0xec08, fontFamily: _fontFamily);
-  static const SolarIconsData filters =
-      SolarIconsData(0xec09, fontFamily: _fontFamily);
-  static const SolarIconsData flipHorizontal =
-      SolarIconsData(0xec0a, fontFamily: _fontFamily);
-  static const SolarIconsData flipVertical =
-      SolarIconsData(0xec0b, fontFamily: _fontFamily);
-  static const SolarIconsData mirrorLeft =
-      SolarIconsData(0xec0c, fontFamily: _fontFamily);
-  static const SolarIconsData cupHot =
-      SolarIconsData(0xec0d, fontFamily: _fontFamily);
-  static const SolarIconsData cupPaper =
-      SolarIconsData(0xec0e, fontFamily: _fontFamily);
-  static const SolarIconsData cup =
-      SolarIconsData(0xec0f, fontFamily: _fontFamily);
-  static const SolarIconsData donutBitten =
-      SolarIconsData(0xec10, fontFamily: _fontFamily);
-  static const SolarIconsData donut =
-      SolarIconsData(0xec11, fontFamily: _fontFamily);
-  static const SolarIconsData teaCup =
-      SolarIconsData(0xec12, fontFamily: _fontFamily);
-  static const SolarIconsData chefHatHeart =
-      SolarIconsData(0xec13, fontFamily: _fontFamily);
-  static const SolarIconsData chefHatMinimalistic =
-      SolarIconsData(0xec14, fontFamily: _fontFamily);
-  static const SolarIconsData corkscrew =
-      SolarIconsData(0xec15, fontFamily: _fontFamily);
-  static const SolarIconsData ladle =
-      SolarIconsData(0xec16, fontFamily: _fontFamily);
-  static const SolarIconsData ovenMittsMinimalistic =
-      SolarIconsData(0xec17, fontFamily: _fontFamily);
-  static const SolarIconsData ovenMitts =
-      SolarIconsData(0xec18, fontFamily: _fontFamily);
-  static const SolarIconsData rollingPin =
-      SolarIconsData(0xec19, fontFamily: _fontFamily);
-  static const SolarIconsData whisk =
-      SolarIconsData(0xec1a, fontFamily: _fontFamily);
-  static const SolarIconsData wineglassTriangle =
-      SolarIconsData(0xec1b, fontFamily: _fontFamily);
-  static const SolarIconsData wineglass =
-      SolarIconsData(0xec1c, fontFamily: _fontFamily);
-  static const SolarIconsData bottle =
-      SolarIconsData(0xec1d, fontFamily: _fontFamily);
-  static const SolarIconsData chefHat =
-      SolarIconsData(0xec1e, fontFamily: _fontFamily);
-  static const SolarIconsData medalRibbonsStart =
-      SolarIconsData(0xec1f, fontFamily: _fontFamily);
-  static const SolarIconsData medalStar =
-      SolarIconsData(0xec20, fontFamily: _fontFamily);
-  static const SolarIconsData startShine =
-      SolarIconsData(0xec21, fontFamily: _fontFamily);
-  static const SolarIconsData start1 =
-      SolarIconsData(0xec22, fontFamily: _fontFamily);
-  static const SolarIconsData medalStarCircle =
-      SolarIconsData(0xec23, fontFamily: _fontFamily);
-  static const SolarIconsData medalStarSquare =
-      SolarIconsData(0xec24, fontFamily: _fontFamily);
-  static const SolarIconsData dislike =
-      SolarIconsData(0xec25, fontFamily: _fontFamily);
-  static const SolarIconsData heartAngle =
-      SolarIconsData(0xec26, fontFamily: _fontFamily);
-  static const SolarIconsData heartBroken =
-      SolarIconsData(0xec27, fontFamily: _fontFamily);
-  static const SolarIconsData heartLock =
-      SolarIconsData(0xec28, fontFamily: _fontFamily);
-  static const SolarIconsData heartShine =
-      SolarIconsData(0xec29, fontFamily: _fontFamily);
-  static const SolarIconsData heartUnlock =
-      SolarIconsData(0xec2a, fontFamily: _fontFamily);
-  static const SolarIconsData heart =
-      SolarIconsData(0xec2b, fontFamily: _fontFamily);
-  static const SolarIconsData hearts =
-      SolarIconsData(0xec2c, fontFamily: _fontFamily);
-  static const SolarIconsData like =
-      SolarIconsData(0xec2d, fontFamily: _fontFamily);
-  static const SolarIconsData medalRibbonStar =
-      SolarIconsData(0xec2e, fontFamily: _fontFamily);
-  static const SolarIconsData medalRibbon =
-      SolarIconsData(0xec2f, fontFamily: _fontFamily);
-  static const SolarIconsData undoRightRoundSquare =
-      SolarIconsData(0xec30, fontFamily: _fontFamily);
-  static const SolarIconsData undoRightRound =
-      SolarIconsData(0xec31, fontFamily: _fontFamily);
-  static const SolarIconsData undoRightSquare =
-      SolarIconsData(0xec32, fontFamily: _fontFamily);
-  static const SolarIconsData undoRight =
-      SolarIconsData(0xec33, fontFamily: _fontFamily);
-  static const SolarIconsData uploadSquare =
-      SolarIconsData(0xec34, fontFamily: _fontFamily);
-  static const SolarIconsData uploadTwiceSquare =
-      SolarIconsData(0xec35, fontFamily: _fontFamily);
-  static const SolarIconsData arrowToDownLeft =
-      SolarIconsData(0xec36, fontFamily: _fontFamily);
-  static const SolarIconsData arrowToDownRight =
-      SolarIconsData(0xec37, fontFamily: _fontFamily);
-  static const SolarIconsData arrowToTopLeft =
-      SolarIconsData(0xec38, fontFamily: _fontFamily);
-  static const SolarIconsData arrowToTopRight =
-      SolarIconsData(0xec39, fontFamily: _fontFamily);
-  static const SolarIconsData forward_2 =
-      SolarIconsData(0xec3a, fontFamily: _fontFamily);
-  static const SolarIconsData reply_2 =
-      SolarIconsData(0xec3b, fontFamily: _fontFamily);
-  static const SolarIconsData circleTopDown =
-      SolarIconsData(0xec3c, fontFamily: _fontFamily);
-  static const SolarIconsData circleTopUp =
-      SolarIconsData(0xec3d, fontFamily: _fontFamily);
-  static const SolarIconsData downloadMinimalistic =
-      SolarIconsData(0xec3e, fontFamily: _fontFamily);
-  static const SolarIconsData download =
-      SolarIconsData(0xec3f, fontFamily: _fontFamily);
-  static const SolarIconsData exit =
-      SolarIconsData(0xec40, fontFamily: _fontFamily);
-  static const SolarIconsData export =
-      SolarIconsData(0xec41, fontFamily: _fontFamily);
-  static const SolarIconsData forward1 =
-      SolarIconsData(0xec42, fontFamily: _fontFamily);
-  static const SolarIconsData import =
-      SolarIconsData(0xec43, fontFamily: _fontFamily);
-  static const SolarIconsData login_2 =
-      SolarIconsData(0xec44, fontFamily: _fontFamily);
-  static const SolarIconsData login_3 =
-      SolarIconsData(0xec45, fontFamily: _fontFamily);
-  static const SolarIconsData login =
-      SolarIconsData(0xec46, fontFamily: _fontFamily);
-  static const SolarIconsData logout_2 =
-      SolarIconsData(0xec47, fontFamily: _fontFamily);
-  static const SolarIconsData logout_3 =
-      SolarIconsData(0xec48, fontFamily: _fontFamily);
-  static const SolarIconsData logout =
-      SolarIconsData(0xec49, fontFamily: _fontFamily);
-  static const SolarIconsData maximizeSquare2 =
-      SolarIconsData(0xec4a, fontFamily: _fontFamily);
-  static const SolarIconsData maximizeSquare3 =
-      SolarIconsData(0xec4b, fontFamily: _fontFamily);
-  static const SolarIconsData maximizeSquareMinimalistic =
-      SolarIconsData(0xec4c, fontFamily: _fontFamily);
-  static const SolarIconsData maximizeSquare =
-      SolarIconsData(0xec4d, fontFamily: _fontFamily);
-  static const SolarIconsData minimizeSquare2 =
-      SolarIconsData(0xec4e, fontFamily: _fontFamily);
-  static const SolarIconsData minimizeSquare3 =
-      SolarIconsData(0xec4f, fontFamily: _fontFamily);
-  static const SolarIconsData minimizeSquareMinimalistic =
-      SolarIconsData(0xec50, fontFamily: _fontFamily);
-  static const SolarIconsData minimizeSquare =
-      SolarIconsData(0xec51, fontFamily: _fontFamily);
-  static const SolarIconsData reorder =
-      SolarIconsData(0xec52, fontFamily: _fontFamily);
-  static const SolarIconsData reply =
-      SolarIconsData(0xec53, fontFamily: _fontFamily);
-  static const SolarIconsData screenShare =
-      SolarIconsData(0xec54, fontFamily: _fontFamily);
-  static const SolarIconsData uploadMinimalistic =
-      SolarIconsData(0xec55, fontFamily: _fontFamily);
-  static const SolarIconsData upload =
-      SolarIconsData(0xec56, fontFamily: _fontFamily);
-  static const SolarIconsData circleBottomDown =
-      SolarIconsData(0xec57, fontFamily: _fontFamily);
-  static const SolarIconsData circleBottomUp =
-      SolarIconsData(0xec58, fontFamily: _fontFamily);
-  static const SolarIconsData downloadSquare =
-      SolarIconsData(0xec59, fontFamily: _fontFamily);
-  static const SolarIconsData downloadTwiceSquare =
-      SolarIconsData(0xec5a, fontFamily: _fontFamily);
-  static const SolarIconsData maximize =
-      SolarIconsData(0xec5b, fontFamily: _fontFamily);
-  static const SolarIconsData minimize =
-      SolarIconsData(0xec5c, fontFamily: _fontFamily);
-  static const SolarIconsData receiveSquare =
-      SolarIconsData(0xec5d, fontFamily: _fontFamily);
-  static const SolarIconsData receiveTwiceSquare =
-      SolarIconsData(0xec5e, fontFamily: _fontFamily);
-  static const SolarIconsData scale =
-      SolarIconsData(0xec5f, fontFamily: _fontFamily);
-  static const SolarIconsData sendSquare =
-      SolarIconsData(0xec60, fontFamily: _fontFamily);
-  static const SolarIconsData sendTwiceSquare =
-      SolarIconsData(0xec61, fontFamily: _fontFamily);
-  static const SolarIconsData squareBottomDown =
-      SolarIconsData(0xec62, fontFamily: _fontFamily);
-  static const SolarIconsData squareBottomUp =
-      SolarIconsData(0xec63, fontFamily: _fontFamily);
-  static const SolarIconsData squareTopDown =
-      SolarIconsData(0xec64, fontFamily: _fontFamily);
-  static const SolarIconsData squareTopUp =
-      SolarIconsData(0xec65, fontFamily: _fontFamily);
-  static const SolarIconsData undoLeftRoundSquare =
-      SolarIconsData(0xec66, fontFamily: _fontFamily);
-  static const SolarIconsData undoLeftRound =
-      SolarIconsData(0xec67, fontFamily: _fontFamily);
-  static const SolarIconsData undoLeftSquare =
-      SolarIconsData(0xec68, fontFamily: _fontFamily);
-  static const SolarIconsData undoLeft =
-      SolarIconsData(0xec69, fontFamily: _fontFamily);
-  static const SolarIconsData notificationRemove =
-      SolarIconsData(0xec6a, fontFamily: _fontFamily);
-  static const SolarIconsData notificationUnreadLines =
-      SolarIconsData(0xec6b, fontFamily: _fontFamily);
-  static const SolarIconsData notificationUnread =
-      SolarIconsData(0xec6c, fontFamily: _fontFamily);
-  static const SolarIconsData bellBing =
-      SolarIconsData(0xec6d, fontFamily: _fontFamily);
-  static const SolarIconsData bellOff =
-      SolarIconsData(0xec6e, fontFamily: _fontFamily);
-  static const SolarIconsData bell =
-      SolarIconsData(0xec6f, fontFamily: _fontFamily);
-  static const SolarIconsData notificationLinesRemove =
-      SolarIconsData(0xec70, fontFamily: _fontFamily);
-  static const SolarIconsData documentText =
-      SolarIconsData(0xec71, fontFamily: _fontFamily);
-  static const SolarIconsData document1 =
-      SolarIconsData(0xec72, fontFamily: _fontFamily);
-  static const SolarIconsData documentsMinimalistic =
-      SolarIconsData(0xec73, fontFamily: _fontFamily);
-  static const SolarIconsData documents =
-      SolarIconsData(0xec74, fontFamily: _fontFamily);
-  static const SolarIconsData notebook1 =
-      SolarIconsData(0xec75, fontFamily: _fontFamily);
-  static const SolarIconsData notesMinimalistic =
-      SolarIconsData(0xec76, fontFamily: _fontFamily);
-  static const SolarIconsData notes =
-      SolarIconsData(0xec77, fontFamily: _fontFamily);
-  static const SolarIconsData archiveCheck =
-      SolarIconsData(0xec78, fontFamily: _fontFamily);
-  static const SolarIconsData archive =
-      SolarIconsData(0xec79, fontFamily: _fontFamily);
-  static const SolarIconsData archiveDownMinimalistic =
-      SolarIconsData(0xec7a, fontFamily: _fontFamily);
-  static const SolarIconsData archiveDown =
-      SolarIconsData(0xec7b, fontFamily: _fontFamily);
-  static const SolarIconsData archiveMinimalistic =
-      SolarIconsData(0xec7c, fontFamily: _fontFamily);
-  static const SolarIconsData archiveUpMinimalistic =
-      SolarIconsData(0xec7d, fontFamily: _fontFamily);
-  static const SolarIconsData archiveUp =
-      SolarIconsData(0xec7e, fontFamily: _fontFamily);
-  static const SolarIconsData clipboardAdd =
-      SolarIconsData(0xec7f, fontFamily: _fontFamily);
-  static const SolarIconsData clipboardCheck =
-      SolarIconsData(0xec80, fontFamily: _fontFamily);
-  static const SolarIconsData clipboardHeart =
-      SolarIconsData(0xec81, fontFamily: _fontFamily);
-  static const SolarIconsData clipboardList =
-      SolarIconsData(0xec82, fontFamily: _fontFamily);
-  static const SolarIconsData clipboardRemove =
-      SolarIconsData(0xec83, fontFamily: _fontFamily);
-  static const SolarIconsData clipboardText =
-      SolarIconsData(0xec84, fontFamily: _fontFamily);
-  static const SolarIconsData clipboard =
-      SolarIconsData(0xec85, fontFamily: _fontFamily);
-  static const SolarIconsData documentAdd =
-      SolarIconsData(0xec86, fontFamily: _fontFamily);
-  static const SolarIconsData documentMedicine =
-      SolarIconsData(0xec87, fontFamily: _fontFamily);
-  static const SolarIconsData lockPassword =
-      SolarIconsData(0xec88, fontFamily: _fontFamily);
-  static const SolarIconsData lockUnlocked =
-      SolarIconsData(0xec89, fontFamily: _fontFamily);
-  static const SolarIconsData lock =
-      SolarIconsData(0xec8a, fontFamily: _fontFamily);
-  static const SolarIconsData passwordMinimalistic =
-      SolarIconsData(0xec8b, fontFamily: _fontFamily);
-  static const SolarIconsData password =
-      SolarIconsData(0xec8c, fontFamily: _fontFamily);
-  static const SolarIconsData sirenRounded =
-      SolarIconsData(0xec8d, fontFamily: _fontFamily);
-  static const SolarIconsData siren =
-      SolarIconsData(0xec8e, fontFamily: _fontFamily);
-  static const SolarIconsData eyeScan =
-      SolarIconsData(0xec8f, fontFamily: _fontFamily);
-  static const SolarIconsData objectScan =
-      SolarIconsData(0xec90, fontFamily: _fontFamily);
-  static const SolarIconsData scanner =
-      SolarIconsData(0xec91, fontFamily: _fontFamily);
-  static const SolarIconsData shieldUp =
-      SolarIconsData(0xec92, fontFamily: _fontFamily);
-  static const SolarIconsData codeScan =
-      SolarIconsData(0xec93, fontFamily: _fontFamily);
-  static const SolarIconsData incognito =
-      SolarIconsData(0xec94, fontFamily: _fontFamily);
-  static const SolarIconsData keyMinimalistic2 =
-      SolarIconsData(0xec95, fontFamily: _fontFamily);
-  static const SolarIconsData keyMinimalisticSquare_2 =
-      SolarIconsData(0xec96, fontFamily: _fontFamily);
-  static const SolarIconsData keyMinimalisticSquare_3 =
-      SolarIconsData(0xec97, fontFamily: _fontFamily);
-  static const SolarIconsData keyMinimalisticSquare =
-      SolarIconsData(0xec98, fontFamily: _fontFamily);
-  static const SolarIconsData keyMinimalistic =
-      SolarIconsData(0xec99, fontFamily: _fontFamily);
-  static const SolarIconsData keySquare_2 =
-      SolarIconsData(0xec9a, fontFamily: _fontFamily);
-  static const SolarIconsData keySquare =
-      SolarIconsData(0xec9b, fontFamily: _fontFamily);
-  static const SolarIconsData key =
-      SolarIconsData(0xec9c, fontFamily: _fontFamily);
-  static const SolarIconsData passwordMinimalisticInput =
-      SolarIconsData(0xec9d, fontFamily: _fontFamily);
-  static const SolarIconsData qrCode =
-      SolarIconsData(0xec9e, fontFamily: _fontFamily);
-  static const SolarIconsData scanner_2 =
-      SolarIconsData(0xec9f, fontFamily: _fontFamily);
-  static const SolarIconsData shieldCheck =
-      SolarIconsData(0xeca0, fontFamily: _fontFamily);
-  static const SolarIconsData shieldCross =
-      SolarIconsData(0xeca1, fontFamily: _fontFamily);
-  static const SolarIconsData shieldKeyholeMinimalistic =
-      SolarIconsData(0xeca2, fontFamily: _fontFamily);
-  static const SolarIconsData shieldKeyhole =
-      SolarIconsData(0xeca3, fontFamily: _fontFamily);
-  static const SolarIconsData shieldMinimalistic =
-      SolarIconsData(0xeca4, fontFamily: _fontFamily);
-  static const SolarIconsData shieldMinus =
-      SolarIconsData(0xeca5, fontFamily: _fontFamily);
-  static const SolarIconsData shieldNetwork =
-      SolarIconsData(0xeca6, fontFamily: _fontFamily);
-  static const SolarIconsData shieldPlus =
-      SolarIconsData(0xeca7, fontFamily: _fontFamily);
-  static const SolarIconsData shieldStar =
-      SolarIconsData(0xeca8, fontFamily: _fontFamily);
-  static const SolarIconsData shieldUser =
-      SolarIconsData(0xeca9, fontFamily: _fontFamily);
-  static const SolarIconsData shieldWarning =
-      SolarIconsData(0xecaa, fontFamily: _fontFamily);
-  static const SolarIconsData shield =
-      SolarIconsData(0xecab, fontFamily: _fontFamily);
-  static const SolarIconsData bombEmoji =
-      SolarIconsData(0xecac, fontFamily: _fontFamily);
-  static const SolarIconsData bombMinimalistic =
-      SolarIconsData(0xecad, fontFamily: _fontFamily);
-  static const SolarIconsData bomb =
-      SolarIconsData(0xecae, fontFamily: _fontFamily);
-  static const SolarIconsData eyeClosed =
-      SolarIconsData(0xecaf, fontFamily: _fontFamily);
-  static const SolarIconsData eye =
-      SolarIconsData(0xecb0, fontFamily: _fontFamily);
-  static const SolarIconsData lockKeyholeMinimalisticUnlocked =
-      SolarIconsData(0xecb1, fontFamily: _fontFamily);
-  static const SolarIconsData lockKeyholeMinimalistic =
-      SolarIconsData(0xecb2, fontFamily: _fontFamily);
-  static const SolarIconsData lockKeyholeUnlocked =
-      SolarIconsData(0xecb3, fontFamily: _fontFamily);
-  static const SolarIconsData lockKeyhole =
-      SolarIconsData(0xecb4, fontFamily: _fontFamily);
-  static const SolarIconsData lockPassword_ =
-      SolarIconsData(0xecb5, fontFamily: _fontFamily);
-  static const SolarIconsData rewind5SecondsForward =
-      SolarIconsData(0xecb6, fontFamily: _fontFamily);
-  static const SolarIconsData soundwaveSquare =
-      SolarIconsData(0xecb7, fontFamily: _fontFamily);
-  static const SolarIconsData soundwave =
-      SolarIconsData(0xecb8, fontFamily: _fontFamily);
-  static const SolarIconsData videoFrameCut =
-      SolarIconsData(0xecb9, fontFamily: _fontFamily);
-  static const SolarIconsData videoFrame =
-      SolarIconsData(0xecba, fontFamily: _fontFamily);
-  static const SolarIconsData volumeLoud =
-      SolarIconsData(0xecbb, fontFamily: _fontFamily);
-  static const SolarIconsData volumeSmall =
-      SolarIconsData(0xecbc, fontFamily: _fontFamily);
-  static const SolarIconsData fullScreenCircle =
-      SolarIconsData(0xecbd, fontFamily: _fontFamily);
-  static const SolarIconsData fullScreenSquare =
-      SolarIconsData(0xecbe, fontFamily: _fontFamily);
-  static const SolarIconsData quitFullScreenCircle =
-      SolarIconsData(0xecbf, fontFamily: _fontFamily);
-  static const SolarIconsData quitFullScreenSquare =
-      SolarIconsData(0xecc0, fontFamily: _fontFamily);
-  static const SolarIconsData quitFullScreen =
-      SolarIconsData(0xecc1, fontFamily: _fontFamily);
-  static const SolarIconsData cameraAdd =
-      SolarIconsData(0xecc2, fontFamily: _fontFamily);
-  static const SolarIconsData cameraMinimalistic =
-      SolarIconsData(0xecc3, fontFamily: _fontFamily);
-  static const SolarIconsData cameraRotate =
-      SolarIconsData(0xecc4, fontFamily: _fontFamily);
-  static const SolarIconsData cameraSquare =
-      SolarIconsData(0xecc5, fontFamily: _fontFamily);
-  static const SolarIconsData camera =
-      SolarIconsData(0xecc6, fontFamily: _fontFamily);
-  static const SolarIconsData fullScreen =
-      SolarIconsData(0xecc7, fontFamily: _fontFamily);
-  static const SolarIconsData galleryCircle =
-      SolarIconsData(0xecc8, fontFamily: _fontFamily);
-  static const SolarIconsData galleryFavourite =
-      SolarIconsData(0xecc9, fontFamily: _fontFamily);
-  static const SolarIconsData galleryRound =
-      SolarIconsData(0xecca, fontFamily: _fontFamily);
-  static const SolarIconsData pip2 =
-      SolarIconsData(0xeccb, fontFamily: _fontFamily);
-  static const SolarIconsData pip =
-      SolarIconsData(0xeccc, fontFamily: _fontFamily);
-  static const SolarIconsData playbackSpeed =
-      SolarIconsData(0xeccd, fontFamily: _fontFamily);
-  static const SolarIconsData quitPIP =
-      SolarIconsData(0xecce, fontFamily: _fontFamily);
-  static const SolarIconsData reel2 =
-      SolarIconsData(0xeccf, fontFamily: _fontFamily);
-  static const SolarIconsData reel =
-      SolarIconsData(0xecd0, fontFamily: _fontFamily);
-  static const SolarIconsData rewindBackCircle =
-      SolarIconsData(0xecd1, fontFamily: _fontFamily);
-  static const SolarIconsData rewindForwardCircle =
-      SolarIconsData(0xecd2, fontFamily: _fontFamily);
-  static const SolarIconsData shuffle =
-      SolarIconsData(0xecd3, fontFamily: _fontFamily);
-  static const SolarIconsData stopCircle =
-      SolarIconsData(0xecd4, fontFamily: _fontFamily);
-  static const SolarIconsData stream =
-      SolarIconsData(0xecd5, fontFamily: _fontFamily);
-  static const SolarIconsData toPIP =
-      SolarIconsData(0xecd6, fontFamily: _fontFamily);
-  static const SolarIconsData videocameraAdd =
-      SolarIconsData(0xecd7, fontFamily: _fontFamily);
-  static const SolarIconsData videocameraRecord =
-      SolarIconsData(0xecd8, fontFamily: _fontFamily);
-  static const SolarIconsData videocamera =
-      SolarIconsData(0xecd9, fontFamily: _fontFamily);
-  static const SolarIconsData clapperboardEdit =
-      SolarIconsData(0xecda, fontFamily: _fontFamily);
-  static const SolarIconsData clapperboardText =
-      SolarIconsData(0xecdb, fontFamily: _fontFamily);
-  static const SolarIconsData galleryCheck =
-      SolarIconsData(0xecdc, fontFamily: _fontFamily);
-  static const SolarIconsData galleryEdit =
-      SolarIconsData(0xecdd, fontFamily: _fontFamily);
-  static const SolarIconsData galleryRemove =
-      SolarIconsData(0xecde, fontFamily: _fontFamily);
-  static const SolarIconsData musicLibrary2 =
-      SolarIconsData(0xecdf, fontFamily: _fontFamily);
-  static const SolarIconsData musicLibrary =
-      SolarIconsData(0xece0, fontFamily: _fontFamily);
-  static const SolarIconsData musicNoteSlider2 =
-      SolarIconsData(0xece1, fontFamily: _fontFamily);
-  static const SolarIconsData musicNoteSlider =
-      SolarIconsData(0xece2, fontFamily: _fontFamily);
-  static const SolarIconsData musicNotes =
-      SolarIconsData(0xece3, fontFamily: _fontFamily);
-  static const SolarIconsData panorama =
-      SolarIconsData(0xece4, fontFamily: _fontFamily);
-  static const SolarIconsData pauseCircle =
-      SolarIconsData(0xece5, fontFamily: _fontFamily);
-  static const SolarIconsData playCircle =
-      SolarIconsData(0xece6, fontFamily: _fontFamily);
-  static const SolarIconsData podcast =
-      SolarIconsData(0xece7, fontFamily: _fontFamily);
-  static const SolarIconsData rewind10SecondsBack =
-      SolarIconsData(0xece8, fontFamily: _fontFamily);
-  static const SolarIconsData rewind10SecondsForward =
-      SolarIconsData(0xece9, fontFamily: _fontFamily);
-  static const SolarIconsData rewindBack =
-      SolarIconsData(0xecea, fontFamily: _fontFamily);
-  static const SolarIconsData skipNext =
-      SolarIconsData(0xeceb, fontFamily: _fontFamily);
-  static const SolarIconsData skipPrevious =
-      SolarIconsData(0xecec, fontFamily: _fontFamily);
-  static const SolarIconsData uploadTrack2 =
-      SolarIconsData(0xeced, fontFamily: _fontFamily);
-  static const SolarIconsData uploadTrack =
-      SolarIconsData(0xecee, fontFamily: _fontFamily);
-  static const SolarIconsData videoFrame2 =
-      SolarIconsData(0xecef, fontFamily: _fontFamily);
-  static const SolarIconsData videoFramePlayHorizontal =
-      SolarIconsData(0xecf0, fontFamily: _fontFamily);
-  static const SolarIconsData videoFramePlayVertical =
-      SolarIconsData(0xecf1, fontFamily: _fontFamily);
-  static const SolarIconsData volumeCross =
-      SolarIconsData(0xecf2, fontFamily: _fontFamily);
-  static const SolarIconsData wallpaper =
-      SolarIconsData(0xecf3, fontFamily: _fontFamily);
-  static const SolarIconsData clapperboardOpenPlay =
-      SolarIconsData(0xecf4, fontFamily: _fontFamily);
-  static const SolarIconsData clapperboardOpen =
-      SolarIconsData(0xecf5, fontFamily: _fontFamily);
-  static const SolarIconsData galleryAdd =
-      SolarIconsData(0xecf6, fontFamily: _fontFamily);
-  static const SolarIconsData galleryDownload =
-      SolarIconsData(0xecf7, fontFamily: _fontFamily);
-  static const SolarIconsData gallerySend =
-      SolarIconsData(0xecf8, fontFamily: _fontFamily);
-  static const SolarIconsData galleryWide =
-      SolarIconsData(0xecf9, fontFamily: _fontFamily);
-  static const SolarIconsData microphone3 =
-      SolarIconsData(0xecfa, fontFamily: _fontFamily);
-  static const SolarIconsData microphoneLarge =
-      SolarIconsData(0xecfb, fontFamily: _fontFamily);
-  static const SolarIconsData microphone =
-      SolarIconsData(0xecfc, fontFamily: _fontFamily);
-  static const SolarIconsData musicNote2 =
-      SolarIconsData(0xecfd, fontFamily: _fontFamily);
-  static const SolarIconsData musicNote =
-      SolarIconsData(0xecfe, fontFamily: _fontFamily);
-  static const SolarIconsData muted =
-      SolarIconsData(0xecff, fontFamily: _fontFamily);
-  static const SolarIconsData pause =
-      SolarIconsData(0xed00, fontFamily: _fontFamily);
-  static const SolarIconsData playStream =
-      SolarIconsData(0xed01, fontFamily: _fontFamily);
-  static const SolarIconsData play =
-      SolarIconsData(0xed02, fontFamily: _fontFamily);
-  static const SolarIconsData repeatOneMinimalistic =
-      SolarIconsData(0xed03, fontFamily: _fontFamily);
-  static const SolarIconsData rewind15SecondsBack =
-      SolarIconsData(0xed04, fontFamily: _fontFamily);
-  static const SolarIconsData rewind15SecondsForward =
-      SolarIconsData(0xed05, fontFamily: _fontFamily);
-  static const SolarIconsData rewindForward =
-      SolarIconsData(0xed06, fontFamily: _fontFamily);
-  static const SolarIconsData soundwaveCircle =
-      SolarIconsData(0xed07, fontFamily: _fontFamily);
-  static const SolarIconsData stop =
-      SolarIconsData(0xed08, fontFamily: _fontFamily);
-  static const SolarIconsData videoFrameCut2 =
-      SolarIconsData(0xed09, fontFamily: _fontFamily);
-  static const SolarIconsData videoFrameReplace =
-      SolarIconsData(0xed0a, fontFamily: _fontFamily);
-  static const SolarIconsData videoLibrary =
-      SolarIconsData(0xed0b, fontFamily: _fontFamily);
-  static const SolarIconsData vinylRecord =
-      SolarIconsData(0xed0c, fontFamily: _fontFamily);
-  static const SolarIconsData vinyl =
-      SolarIconsData(0xed0d, fontFamily: _fontFamily);
-  static const SolarIconsData volume =
-      SolarIconsData(0xed0e, fontFamily: _fontFamily);
-  static const SolarIconsData album =
-      SolarIconsData(0xed0f, fontFamily: _fontFamily);
-  static const SolarIconsData clapperboardPlay =
-      SolarIconsData(0xed10, fontFamily: _fontFamily);
-  static const SolarIconsData clapperboard =
-      SolarIconsData(0xed11, fontFamily: _fontFamily);
-  static const SolarIconsData galleryMinimalistic =
-      SolarIconsData(0xed12, fontFamily: _fontFamily);
-  static const SolarIconsData gallery =
-      SolarIconsData(0xed13, fontFamily: _fontFamily);
-  static const SolarIconsData library =
-      SolarIconsData(0xed14, fontFamily: _fontFamily);
-  static const SolarIconsData microphone2 =
-      SolarIconsData(0xed15, fontFamily: _fontFamily);
-  static const SolarIconsData musicNote3 =
-      SolarIconsData(0xed16, fontFamily: _fontFamily);
-  static const SolarIconsData musicNote4 =
-      SolarIconsData(0xed17, fontFamily: _fontFamily);
-  static const SolarIconsData recordCircle1 =
-      SolarIconsData(0xed18, fontFamily: _fontFamily);
-  static const SolarIconsData record =
-      SolarIconsData(0xed19, fontFamily: _fontFamily);
-  static const SolarIconsData repeatOne =
-      SolarIconsData(0xed1a, fontFamily: _fontFamily);
-  static const SolarIconsData repeat =
-      SolarIconsData(0xed1b, fontFamily: _fontFamily);
-  static const SolarIconsData rewind5SecondsBack =
-      SolarIconsData(0xed1c, fontFamily: _fontFamily);
-  static const SolarIconsData dangerTriangle =
-      SolarIconsData(0xed1d, fontFamily: _fontFamily);
-  static const SolarIconsData danger =
-      SolarIconsData(0xed1e, fontFamily: _fontFamily);
-  static const SolarIconsData forbiddenCircle =
-      SolarIconsData(0xed1f, fontFamily: _fontFamily);
-  static const SolarIconsData forbidden =
-      SolarIconsData(0xed20, fontFamily: _fontFamily);
-  static const SolarIconsData infoCircle =
-      SolarIconsData(0xed21, fontFamily: _fontFamily);
-  static const SolarIconsData minusCircle =
-      SolarIconsData(0xed22, fontFamily: _fontFamily);
-  static const SolarIconsData questionCircle =
-      SolarIconsData(0xed23, fontFamily: _fontFamily);
-  static const SolarIconsData maskHapply =
-      SolarIconsData(0xed24, fontFamily: _fontFamily);
-  static const SolarIconsData maskSad =
-      SolarIconsData(0xed25, fontFamily: _fontFamily);
-  static const SolarIconsData masks =
-      SolarIconsData(0xed26, fontFamily: _fontFamily);
-  static const SolarIconsData mentionCircle =
-      SolarIconsData(0xed27, fontFamily: _fontFamily);
-  static const SolarIconsData mentionSquare =
-      SolarIconsData(0xed28, fontFamily: _fontFamily);
-  static const SolarIconsData accessibility =
-      SolarIconsData(0xed29, fontFamily: _fontFamily);
-  static const SolarIconsData body =
-      SolarIconsData(0xed2a, fontFamily: _fontFamily);
-  static const SolarIconsData confettiMinimalistic =
-      SolarIconsData(0xed2b, fontFamily: _fontFamily);
-  static const SolarIconsData confetti =
-      SolarIconsData(0xed2c, fontFamily: _fontFamily);
-  static const SolarIconsData cosmetic =
-      SolarIconsData(0xed2d, fontFamily: _fontFamily);
-  static const SolarIconsData cursorSquare =
-      SolarIconsData(0xed2e, fontFamily: _fontFamily);
-  static const SolarIconsData cursor =
-      SolarIconsData(0xed2f, fontFamily: _fontFamily);
-  static const SolarIconsData delivery =
-      SolarIconsData(0xed30, fontFamily: _fontFamily);
-  static const SolarIconsData ferrisWheel =
-      SolarIconsData(0xed31, fontFamily: _fontFamily);
-  static const SolarIconsData flashlightOn =
-      SolarIconsData(0xed32, fontFamily: _fontFamily);
-  static const SolarIconsData flashlight =
-      SolarIconsData(0xed33, fontFamily: _fontFamily);
-  static const SolarIconsData gift =
-      SolarIconsData(0xed34, fontFamily: _fontFamily);
-  static const SolarIconsData hanger_2 =
-      SolarIconsData(0xed35, fontFamily: _fontFamily);
-  static const SolarIconsData hanger =
-      SolarIconsData(0xed36, fontFamily: _fontFamily);
-  static const SolarIconsData magicStick_2 =
-      SolarIconsData(0xed37, fontFamily: _fontFamily);
-  static const SolarIconsData magicStick_3 =
-      SolarIconsData(0xed38, fontFamily: _fontFamily);
-  static const SolarIconsData magicStick =
-      SolarIconsData(0xed39, fontFamily: _fontFamily);
-  static const SolarIconsData magnetWave =
-      SolarIconsData(0xed3a, fontFamily: _fontFamily);
-  static const SolarIconsData magnet =
-      SolarIconsData(0xed3b, fontFamily: _fontFamily);
-  static const SolarIconsData mirror1 =
-      SolarIconsData(0xed3c, fontFamily: _fontFamily);
-  static const SolarIconsData perfume =
-      SolarIconsData(0xed3d, fontFamily: _fontFamily);
-  static const SolarIconsData skirt =
-      SolarIconsData(0xed3e, fontFamily: _fontFamily);
-  static const SolarIconsData sledgehammer =
-      SolarIconsData(0xed3f, fontFamily: _fontFamily);
-  static const SolarIconsData sleeping =
-      SolarIconsData(0xed40, fontFamily: _fontFamily);
-  static const SolarIconsData tShirt =
-      SolarIconsData(0xed41, fontFamily: _fontFamily);
-  static const SolarIconsData k =
-      SolarIconsData(0xed42, fontFamily: _fontFamily);
-  static const SolarIconsData augmentedReality =
-      SolarIconsData(0xed43, fontFamily: _fontFamily);
-  static const SolarIconsData boxMinimalistic =
-      SolarIconsData(0xed44, fontFamily: _fontFamily);
-  static const SolarIconsData box =
-      SolarIconsData(0xed45, fontFamily: _fontFamily);
-  static const SolarIconsData copyright =
-      SolarIconsData(0xed46, fontFamily: _fontFamily);
-  static const SolarIconsData creativeCommons =
-      SolarIconsData(0xed47, fontFamily: _fontFamily);
-  static const SolarIconsData cupFirst =
-      SolarIconsData(0xed48, fontFamily: _fontFamily);
-  static const SolarIconsData cupMusic =
-      SolarIconsData(0xed49, fontFamily: _fontFamily);
-  static const SolarIconsData cupStar =
-      SolarIconsData(0xed4a, fontFamily: _fontFamily);
-  static const SolarIconsData cup1 =
-      SolarIconsData(0xed4b, fontFamily: _fontFamily);
-  static const SolarIconsData explicit =
-      SolarIconsData(0xed4c, fontFamily: _fontFamily);
-  static const SolarIconsData feed =
-      SolarIconsData(0xed4d, fontFamily: _fontFamily);
-  static const SolarIconsData filter =
-      SolarIconsData(0xed4e, fontFamily: _fontFamily);
-  static const SolarIconsData glasses =
-      SolarIconsData(0xed4f, fontFamily: _fontFamily);
-  static const SolarIconsData hamburgerMenu =
-      SolarIconsData(0xed50, fontFamily: _fontFamily);
-  static const SolarIconsData highDefinition =
-      SolarIconsData(0xed51, fontFamily: _fontFamily);
-  static const SolarIconsData highQuality =
-      SolarIconsData(0xed52, fontFamily: _fontFamily);
-  static const SolarIconsData paperBin =
-      SolarIconsData(0xed53, fontFamily: _fontFamily);
-  static const SolarIconsData paw =
-      SolarIconsData(0xed54, fontFamily: _fontFamily);
-  static const SolarIconsData reorder1 =
-      SolarIconsData(0xed55, fontFamily: _fontFamily);
-  static const SolarIconsData scissorsSquare =
-      SolarIconsData(0xed56, fontFamily: _fontFamily);
-  static const SolarIconsData scissors =
-      SolarIconsData(0xed57, fontFamily: _fontFamily);
-  static const SolarIconsData sort =
-      SolarIconsData(0xed58, fontFamily: _fontFamily);
-  static const SolarIconsData specialEffects =
-      SolarIconsData(0xed59, fontFamily: _fontFamily);
-  static const SolarIconsData xxx =
-      SolarIconsData(0xed5a, fontFamily: _fontFamily);
-  static const SolarIconsData balloon =
-      SolarIconsData(0xed5b, fontFamily: _fontFamily);
-  static const SolarIconsData boltCircle =
-      SolarIconsData(0xed5c, fontFamily: _fontFamily);
-  static const SolarIconsData bolt =
-      SolarIconsData(0xed5d, fontFamily: _fontFamily);
-  static const SolarIconsData broom =
-      SolarIconsData(0xed5e, fontFamily: _fontFamily);
-  static const SolarIconsData cat =
-      SolarIconsData(0xed5f, fontFamily: _fontFamily);
-  static const SolarIconsData copy =
-      SolarIconsData(0xed60, fontFamily: _fontFamily);
-  static const SolarIconsData figma =
-      SolarIconsData(0xed61, fontFamily: _fontFamily);
-  static const SolarIconsData flag_2 =
-      SolarIconsData(0xed62, fontFamily: _fontFamily);
-  static const SolarIconsData flag =
-      SolarIconsData(0xed63, fontFamily: _fontFamily);
-  static const SolarIconsData fuel =
-      SolarIconsData(0xed64, fontFamily: _fontFamily);
-  static const SolarIconsData ghostSmile =
-      SolarIconsData(0xed65, fontFamily: _fontFamily);
-  static const SolarIconsData ghost =
-      SolarIconsData(0xed66, fontFamily: _fontFamily);
-  static const SolarIconsData help =
-      SolarIconsData(0xed67, fontFamily: _fontFamily);
-  static const SolarIconsData plate =
-      SolarIconsData(0xed68, fontFamily: _fontFamily);
-  static const SolarIconsData postsCarouselHorizontal =
-      SolarIconsData(0xed69, fontFamily: _fontFamily);
-  static const SolarIconsData postsCarouselVertical =
-      SolarIconsData(0xed6a, fontFamily: _fontFamily);
-  static const SolarIconsData power =
-      SolarIconsData(0xed6b, fontFamily: _fontFamily);
-  static const SolarIconsData shareCircle =
-      SolarIconsData(0xed6c, fontFamily: _fontFamily);
-  static const SolarIconsData share =
-      SolarIconsData(0xed6d, fontFamily: _fontFamily);
-  static const SolarIconsData subtitles =
-      SolarIconsData(0xed6e, fontFamily: _fontFamily);
-  static const SolarIconsData target =
-      SolarIconsData(0xed6f, fontFamily: _fontFamily);
-  static const SolarIconsData trashBin2 =
-      SolarIconsData(0xed70, fontFamily: _fontFamily);
-  static const SolarIconsData umbrella =
-      SolarIconsData(0xed71, fontFamily: _fontFamily);
-  static const SolarIconsData waterdrop =
-      SolarIconsData(0xed72, fontFamily: _fontFamily);
-  static const SolarIconsData winRar =
-      SolarIconsData(0xed73, fontFamily: _fontFamily);
-  static const SolarIconsData batteryChargeMinimalistic =
-      SolarIconsData(0xed74, fontFamily: _fontFamily);
-  static const SolarIconsData batteryCharge =
-      SolarIconsData(0xed75, fontFamily: _fontFamily);
-  static const SolarIconsData batteryFullMinimalistic =
-      SolarIconsData(0xed76, fontFamily: _fontFamily);
-  static const SolarIconsData batteryFull =
-      SolarIconsData(0xed77, fontFamily: _fontFamily);
-  static const SolarIconsData batteryHalfMinimalistic =
-      SolarIconsData(0xed78, fontFamily: _fontFamily);
-  static const SolarIconsData batteryHalf =
-      SolarIconsData(0xed79, fontFamily: _fontFamily);
-  static const SolarIconsData batteryLowMinimalistic =
-      SolarIconsData(0xed7a, fontFamily: _fontFamily);
-  static const SolarIconsData batteryLow =
-      SolarIconsData(0xed7b, fontFamily: _fontFamily);
-  static const SolarIconsData crownLine =
-      SolarIconsData(0xed7c, fontFamily: _fontFamily);
-  static const SolarIconsData crownMinimalistic =
-      SolarIconsData(0xed7d, fontFamily: _fontFamily);
-  static const SolarIconsData crownStar =
-      SolarIconsData(0xed7e, fontFamily: _fontFamily);
-  static const SolarIconsData crown =
-      SolarIconsData(0xed7f, fontFamily: _fontFamily);
-  static const SolarIconsData database =
-      SolarIconsData(0xed80, fontFamily: _fontFamily);
-  static const SolarIconsData homeWiFiAngle =
-      SolarIconsData(0xed81, fontFamily: _fontFamily);
-  static const SolarIconsData pinCircle =
-      SolarIconsData(0xed82, fontFamily: _fontFamily);
-  static const SolarIconsData pinList =
-      SolarIconsData(0xed83, fontFamily: _fontFamily);
-  static const SolarIconsData pin =
-      SolarIconsData(0xed84, fontFamily: _fontFamily);
-  static const SolarIconsData sliderHorizontal =
-      SolarIconsData(0xed85, fontFamily: _fontFamily);
-  static const SolarIconsData sliderMinimalisticHorizontal =
-      SolarIconsData(0xed86, fontFamily: _fontFamily);
-  static const SolarIconsData sliderVerticalMinimalistic =
-      SolarIconsData(0xed87, fontFamily: _fontFamily);
-  static const SolarIconsData sliderVertical =
-      SolarIconsData(0xed88, fontFamily: _fontFamily);
-  static const SolarIconsData smartHomeAngle =
-      SolarIconsData(0xed89, fontFamily: _fontFamily);
-  static const SolarIconsData trafficEconomy =
-      SolarIconsData(0xed8a, fontFamily: _fontFamily);
-  static const SolarIconsData traffic =
-      SolarIconsData(0xed8b, fontFamily: _fontFamily);
-  static const SolarIconsData trashBinMinimalistic_2 =
-      SolarIconsData(0xed8c, fontFamily: _fontFamily);
-  static const SolarIconsData trashBinMinimalistic =
-      SolarIconsData(0xed8d, fontFamily: _fontFamily);
-  static const SolarIconsData trashBinTrash =
-      SolarIconsData(0xed8e, fontFamily: _fontFamily);
-  static const SolarIconsData addSquare =
-      SolarIconsData(0xed8f, fontFamily: _fontFamily);
-  static const SolarIconsData checkSquare =
-      SolarIconsData(0xed90, fontFamily: _fontFamily);
-  static const SolarIconsData closeSquare =
-      SolarIconsData(0xed91, fontFamily: _fontFamily);
-  static const SolarIconsData dangerSquare =
-      SolarIconsData(0xed92, fontFamily: _fontFamily);
-  static const SolarIconsData home2 =
-      SolarIconsData(0xed93, fontFamily: _fontFamily);
-  static const SolarIconsData homeAddAngle =
-      SolarIconsData(0xed94, fontFamily: _fontFamily);
-  static const SolarIconsData homeAdd =
-      SolarIconsData(0xed95, fontFamily: _fontFamily);
-  static const SolarIconsData homeAngle_2 =
-      SolarIconsData(0xed96, fontFamily: _fontFamily);
-  static const SolarIconsData homeAngle =
-      SolarIconsData(0xed97, fontFamily: _fontFamily);
-  static const SolarIconsData homeSmileAngle =
-      SolarIconsData(0xed98, fontFamily: _fontFamily);
-  static const SolarIconsData homeSmile =
-      SolarIconsData(0xed99, fontFamily: _fontFamily);
-  static const SolarIconsData homeWiFi =
-      SolarIconsData(0xed9a, fontFamily: _fontFamily);
-  static const SolarIconsData home =
-      SolarIconsData(0xed9b, fontFamily: _fontFamily);
-  static const SolarIconsData infoSquare =
-      SolarIconsData(0xed9c, fontFamily: _fontFamily);
-  static const SolarIconsData menuDotsCircle =
-      SolarIconsData(0xed9d, fontFamily: _fontFamily);
-  static const SolarIconsData menuDotsSquare =
-      SolarIconsData(0xed9e, fontFamily: _fontFamily);
-  static const SolarIconsData menuDots =
-      SolarIconsData(0xed9f, fontFamily: _fontFamily);
-  static const SolarIconsData minusSquare =
-      SolarIconsData(0xeda0, fontFamily: _fontFamily);
-  static const SolarIconsData questionSquare =
-      SolarIconsData(0xeda1, fontFamily: _fontFamily);
-  static const SolarIconsData revote =
-      SolarIconsData(0xeda2, fontFamily: _fontFamily);
-  static const SolarIconsData smartHome =
-      SolarIconsData(0xeda3, fontFamily: _fontFamily);
-  static const SolarIconsData addCircle =
-      SolarIconsData(0xeda4, fontFamily: _fontFamily);
-  static const SolarIconsData checkCircle =
-      SolarIconsData(0xeda5, fontFamily: _fontFamily);
-  static const SolarIconsData closeCircle =
-      SolarIconsData(0xeda6, fontFamily: _fontFamily);
-  static const SolarIconsData dangerCircle =
-      SolarIconsData(0xeda7, fontFamily: _fontFamily);
-  static const SolarIconsData userPlus =
-      SolarIconsData(0xeda8, fontFamily: _fontFamily);
-  static const SolarIconsData userRounded =
-      SolarIconsData(0xeda9, fontFamily: _fontFamily);
-  static const SolarIconsData userSpeakRounded =
-      SolarIconsData(0xedaa, fontFamily: _fontFamily);
-  static const SolarIconsData user =
-      SolarIconsData(0xedab, fontFamily: _fontFamily);
-  static const SolarIconsData usersGroupRounded =
-      SolarIconsData(0xedac, fontFamily: _fontFamily);
-  static const SolarIconsData usersGroupTwoRounded =
-      SolarIconsData(0xedad, fontFamily: _fontFamily);
-  static const SolarIconsData userHandUp =
-      SolarIconsData(0xedae, fontFamily: _fontFamily);
-  static const SolarIconsData userHands =
-      SolarIconsData(0xedaf, fontFamily: _fontFamily);
-  static const SolarIconsData userHeart =
-      SolarIconsData(0xedb0, fontFamily: _fontFamily);
-  static const SolarIconsData userSpeak =
-      SolarIconsData(0xedb1, fontFamily: _fontFamily);
-  static const SolarIconsData userBlockRounded =
-      SolarIconsData(0xedb2, fontFamily: _fontFamily);
-  static const SolarIconsData userBlock =
-      SolarIconsData(0xedb3, fontFamily: _fontFamily);
-  static const SolarIconsData userCheckRounded =
-      SolarIconsData(0xedb4, fontFamily: _fontFamily);
-  static const SolarIconsData userCheck =
-      SolarIconsData(0xedb5, fontFamily: _fontFamily);
-  static const SolarIconsData userCircle =
-      SolarIconsData(0xedb6, fontFamily: _fontFamily);
-  static const SolarIconsData userCrossRounded =
-      SolarIconsData(0xedb7, fontFamily: _fontFamily);
-  static const SolarIconsData userCross =
-      SolarIconsData(0xedb8, fontFamily: _fontFamily);
-  static const SolarIconsData userHeartRounded =
-      SolarIconsData(0xedb9, fontFamily: _fontFamily);
-  static const SolarIconsData userId =
-      SolarIconsData(0xedba, fontFamily: _fontFamily);
-  static const SolarIconsData userMinusRounded =
-      SolarIconsData(0xedbb, fontFamily: _fontFamily);
-  static const SolarIconsData userMinus =
-      SolarIconsData(0xedbc, fontFamily: _fontFamily);
-  static const SolarIconsData userPlusRounded =
-      SolarIconsData(0xedbd, fontFamily: _fontFamily);
-  static const SolarIconsData handPills =
-      SolarIconsData(0xedbe, fontFamily: _fontFamily);
-  static const SolarIconsData handShake =
-      SolarIconsData(0xedbf, fontFamily: _fontFamily);
-  static const SolarIconsData handStars =
-      SolarIconsData(0xedc0, fontFamily: _fontFamily);
-  static const SolarIconsData handHeart =
-      SolarIconsData(0xedc1, fontFamily: _fontFamily);
-  static const SolarIconsData handMoney =
-      SolarIconsData(0xedc2, fontFamily: _fontFamily);
-  static const SolarIconsData garage =
-      SolarIconsData(0xedc3, fontFamily: _fontFamily);
-  static const SolarIconsData home1 =
-      SolarIconsData(0xedc4, fontFamily: _fontFamily);
-  static const SolarIconsData hospital =
-      SolarIconsData(0xedc5, fontFamily: _fontFamily);
-  static const SolarIconsData buildings_2 =
-      SolarIconsData(0xedc6, fontFamily: _fontFamily);
-  static const SolarIconsData buildings_3 =
-      SolarIconsData(0xedc7, fontFamily: _fontFamily);
-  static const SolarIconsData buildings =
-      SolarIconsData(0xedc8, fontFamily: _fontFamily);
-  static const SolarIconsData city =
-      SolarIconsData(0xedc9, fontFamily: _fontFamily);
-  static const SolarIconsData suspension =
-      SolarIconsData(0xedca, fontFamily: _fontFamily);
-  static const SolarIconsData transmissionCircle =
-      SolarIconsData(0xedcb, fontFamily: _fontFamily);
-  static const SolarIconsData transmissionSquare =
-      SolarIconsData(0xedcc, fontFamily: _fontFamily);
-  static const SolarIconsData transmission =
-      SolarIconsData(0xedcd, fontFamily: _fontFamily);
-  static const SolarIconsData bus =
-      SolarIconsData(0xedce, fontFamily: _fontFamily);
-  static const SolarIconsData kickScooter =
-      SolarIconsData(0xedcf, fontFamily: _fontFamily);
-  static const SolarIconsData scooter =
-      SolarIconsData(0xedd0, fontFamily: _fontFamily);
-  static const SolarIconsData speedometerLow =
-      SolarIconsData(0xedd1, fontFamily: _fontFamily);
-  static const SolarIconsData speedometerMax =
-      SolarIconsData(0xedd2, fontFamily: _fontFamily);
-  static const SolarIconsData speedometerMiddle =
-      SolarIconsData(0xedd3, fontFamily: _fontFamily);
-  static const SolarIconsData tram =
-      SolarIconsData(0xedd4, fontFamily: _fontFamily);
-  static const SolarIconsData wheelAngle =
-      SolarIconsData(0xedd5, fontFamily: _fontFamily);
-  static const SolarIconsData wheel =
-      SolarIconsData(0xedd6, fontFamily: _fontFamily);
-  static const SolarIconsData accumulator =
-      SolarIconsData(0xedd7, fontFamily: _fontFamily);
-  static const SolarIconsData electricRefueling =
-      SolarIconsData(0xedd8, fontFamily: _fontFamily);
-  static const SolarIconsData gasStation =
-      SolarIconsData(0xedd9, fontFamily: _fontFamily);
-  static const SolarIconsData shockAbsorber =
-      SolarIconsData(0xedda, fontFamily: _fontFamily);
-  static const SolarIconsData suspensionBolt =
-      SolarIconsData(0xeddb, fontFamily: _fontFamily);
-  static const SolarIconsData suspensionCross =
-      SolarIconsData(0xeddc, fontFamily: _fontFamily);
+  static const multipleForwardLeft = IconData(0xe900, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const multipleForwardRight = IconData(0xe901, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const paperclip2 = IconData(0xe902, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const paperclipRounded2 = IconData(0xe903, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const paperclipRounded = IconData(0xe904, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const paperclip = IconData(0xe905, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const plain2 = IconData(0xe906, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const plain3 = IconData(0xe907, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const plain = IconData(0xe908, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareForward = IconData(0xe909, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareShareLine = IconData(0xe90a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chatSquareArrow = IconData(0xe90b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chatSquareCall = IconData(0xe90c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chatRead = IconData(0xe90d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const forward = IconData(0xe90e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const inboxArchive = IconData(0xe90f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const inboxIn = IconData(0xe910, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const inboxLine = IconData(0xe911, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const inboxOut = IconData(0xe912, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const inboxUnread = IconData(0xe913, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const inbox = IconData(0xe914, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const letterOpened = IconData(0xe915, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const letterUnread = IconData(0xe916, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const letter = IconData(0xe917, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mailbox = IconData(0xe918, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const pen2 = IconData(0xe919, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const penNewRound = IconData(0xe91a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const penNewSquare = IconData(0xe91b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const pen = IconData(0xe91c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const unread = IconData(0xe91d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chatSquareCheck = IconData(0xe91e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chatSquareCode = IconData(0xe91f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chatSquareLike = IconData(0xe920, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chatSquare = IconData(0xe921, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chatDots = IconData(0xe922, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chatLine = IconData(0xe923, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chatRoundCall = IconData(0xe924, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chatRoundCheck = IconData(0xe925, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chatRoundDots = IconData(0xe926, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chatRoundLike = IconData(0xe927, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chatRoundLine = IconData(0xe928, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chatRoundMoney = IconData(0xe929, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chatRoundUnread = IconData(0xe92a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chatRoundVideo = IconData(0xe92b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chatRound = IconData(0xe92c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chatUnread = IconData(0xe92d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const dialog2 = IconData(0xe92e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const dialog = IconData(0xe92f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const refreshSquare = IconData(0xe930, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const restartCircle = IconData(0xe931, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const restartSquare = IconData(0xe932, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const altArrowDown = IconData(0xe933, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const altArrowLeft = IconData(0xe934, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const altArrowRight = IconData(0xe935, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const altArrowUp = IconData(0xe936, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const arrowDown = IconData(0xe937, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const arrowLeftDown = IconData(0xe938, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const arrowLeftUp = IconData(0xe939, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const arrowLeft = IconData(0xe93a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const arrowRightDown = IconData(0xe93b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const arrowRightUp = IconData(0xe93c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const arrowRight = IconData(0xe93d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const arrowUp = IconData(0xe93e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const doubleAltArrowDown = IconData(0xe93f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const doubleAltArrowLeft = IconData(0xe940, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const doubleAltArrowRight = IconData(0xe941, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const doubleAltArrowUp = IconData(0xe942, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const refreshCircle = IconData(0xe943, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const refresh = IconData(0xe944, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const restart = IconData(0xe945, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundAltArrowDown = IconData(0xe946, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundAltArrowUp = IconData(0xe947, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundArrowLeftUp = IconData(0xe948, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundArrowRightDown = IconData(0xe949, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundArrowRightUp = IconData(0xe94a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundArrowRight = IconData(0xe94b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundDoubleAltArrowDown = IconData(0xe94c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundDoubleAltArrowLeft = IconData(0xe94d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundDoubleAltArrowRight = IconData(0xe94e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundDoubleAltArrowUp = IconData(0xe94f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundSortHorizontal = IconData(0xe950, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundSortVertical = IconData(0xe951, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundTransferDiagonal = IconData(0xe952, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundTransferHorizontal = IconData(0xe953, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundTransferVertical = IconData(0xe954, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sortHorizontal = IconData(0xe955, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const transferHorizontal = IconData(0xe956, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const transferVertical = IconData(0xe957, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundAltArrowLeft = IconData(0xe958, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundAltArrowRight = IconData(0xe959, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundArrowDown = IconData(0xe95a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundArrowLeftDown = IconData(0xe95b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundArrowLeft = IconData(0xe95c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundArrowUp = IconData(0xe95d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareAltArrowDown = IconData(0xe95e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareArrowDown = IconData(0xe95f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareArrowLeftDown = IconData(0xe960, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareArrowLeftUp = IconData(0xe961, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareArrowLeft = IconData(0xe962, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareArrowRightDown = IconData(0xe963, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareArrowRightUp = IconData(0xe964, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareArrowRight = IconData(0xe965, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareArrowUp = IconData(0xe966, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareSortHorizontal = IconData(0xe967, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareSortVertical = IconData(0xe968, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareTransferHorizontal = IconData(0xe969, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareTransferVertical = IconData(0xe96a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareAltArrowLeft = IconData(0xe96b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareAltArrowRight = IconData(0xe96c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareAltArrowUp = IconData(0xe96d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareDoubleAltArrowRight = IconData(0xe96e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareDoubleAltArrowDown = IconData(0xe96f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareDoubleAltArrowLeft = IconData(0xe970, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareDoubleAltArrowUp = IconData(0xe971, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const compassBig = IconData(0xe972, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const globus = IconData(0xe973, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const gps = IconData(0xe974, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const branchingPathsDown = IconData(0xe975, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const branchingPathsUp = IconData(0xe976, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mapArrowDown = IconData(0xe977, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mapArrowLeft = IconData(0xe978, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mapArrowRight = IconData(0xe979, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mapArrowSquare = IconData(0xe97a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mapArrowUp = IconData(0xe97b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const pointOnMapPerspective = IconData(0xe97c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const radar2 = IconData(0xe97d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const radar = IconData(0xe97e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const route = IconData(0xe97f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const routing2 = IconData(0xe980, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const routing3 = IconData(0xe981, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const routing = IconData(0xe982, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const signpost2 = IconData(0xe983, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const signpost = IconData(0xe984, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const streetsMapPoint = IconData(0xe985, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const streetsNavigation = IconData(0xe986, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const streets = IconData(0xe987, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const compassSquare = IconData(0xe988, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const compass = IconData(0xe989, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const global = IconData(0xe98a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mapPointAdd = IconData(0xe98b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mapPointFavourite = IconData(0xe98c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mapPointHospital = IconData(0xe98d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mapPointRemove = IconData(0xe98e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mapPointRotate = IconData(0xe98f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mapPointSchool = IconData(0xe990, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mapPointSearch = IconData(0xe991, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mapPointWave = IconData(0xe992, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mapPoint = IconData(0xe993, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const map = IconData(0xe994, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const peopleNearby = IconData(0xe995, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const pointOnMap = IconData(0xe996, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const banknote2 = IconData(0xe997, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const banknote = IconData(0xe998, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const billCheck = IconData(0xe999, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const billCross = IconData(0xe99a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const billList = IconData(0xe99b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bill = IconData(0xe99c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cashOut = IconData(0xe99d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const dollarMinimalistic = IconData(0xe99e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const dollar = IconData(0xe99f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const moneyBag = IconData(0xe9a0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const ruble = IconData(0xe9a1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const safe2 = IconData(0xe9a2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const safeCircle = IconData(0xe9a3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const safeSquare = IconData(0xe9a4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const wadOfMoney = IconData(0xe9a5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const card2 = IconData(0xe9a6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cardReceive = IconData(0xe9a7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cardSearch = IconData(0xe9a8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cardSend = IconData(0xe9a9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cardTransfer = IconData(0xe9aa, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const card = IconData(0xe9ab, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cardholder = IconData(0xe9ac, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const euro = IconData(0xe9ad, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const saleSquare = IconData(0xe9ae, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sale = IconData(0xe9af, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const tagHorizontal = IconData(0xe9b0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const tagPrice = IconData(0xe9b1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const tag = IconData(0xe9b2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const tickerStar = IconData(0xe9b3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const ticketSale = IconData(0xe9b4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const ticket = IconData(0xe9b5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const verifiedCheck = IconData(0xe9b6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const wallet2 = IconData(0xe9b7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const walletMoney = IconData(0xe9b8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const wallet = IconData(0xe9b9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const flashDrive = IconData(0xe9ba, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const lightbulbBold = IconData(0xe9bb, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const lightbulbMinimalistic = IconData(0xe9bc, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const lightbulb = IconData(0xe9bd, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const lightning = IconData(0xe9be, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const socket = IconData(0xe9bf, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const weigher = IconData(0xe9c0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bluetoothCircle = IconData(0xe9c1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bluetoothSquare = IconData(0xe9c2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cloudStorage = IconData(0xe9c3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const devices = IconData(0xe9c4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const diskette = IconData(0xe9c5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const display = IconData(0xe9c6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const gameboy = IconData(0xe9c7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const keyboard = IconData(0xe9c8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const plugCircle = IconData(0xe9c9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const projector = IconData(0xe9ca, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const radioMinimalistic = IconData(0xe9cb, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const radio = IconData(0xe9cc, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sdCard = IconData(0xe9cd, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const simCardMinimalistic = IconData(0xe9ce, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const simCard = IconData(0xe9cf, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const simCards = IconData(0xe9d0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const smartSpeaker2 = IconData(0xe9d1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const smartSpeakerMinimalistic = IconData(0xe9d2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const smartSpeaker = IconData(0xe9d3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const ssdRound = IconData(0xe9d4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const ssdSquare = IconData(0xe9d5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const telescope = IconData(0xe9d6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const tv = IconData(0xe9d7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const wirelessCharge = IconData(0xe9d8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const airbudsCharge = IconData(0xe9d9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const airbudsLeft = IconData(0xe9da, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const airbudsRemove = IconData(0xe9db, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const airbudsRight = IconData(0xe9dc, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bluetoothWave = IconData(0xe9dd, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bluetooth = IconData(0xe9de, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const boombox = IconData(0xe9df, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cassette2 = IconData(0xe9e0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cassette = IconData(0xe9e1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cpuBolt = IconData(0xe9e2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cpu = IconData(0xe9e3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const laptop2 = IconData(0xe9e4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const laptop3 = IconData(0xe9e5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const laptopMinimalistic = IconData(0xe9e6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const laptop = IconData(0xe9e7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const monitorCamera = IconData(0xe9e8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const monitorSmartphone = IconData(0xe9e9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const monitor = IconData(0xe9ea, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const printer2 = IconData(0xe9eb, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const printerMinimalistic = IconData(0xe9ec, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const printer = IconData(0xe9ed, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const turntableMinimalistic = IconData(0xe9ee, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const turntableMusicNote = IconData(0xe9ef, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const turntable = IconData(0xe9f0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const airbudsCaseCharge = IconData(0xe9f1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const airbudsCaseMinimalistic = IconData(0xe9f2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const airbudsCaseOpen = IconData(0xe9f3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const airbudsCase = IconData(0xe9f4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const airbudsCheck = IconData(0xe9f5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const airbuds = IconData(0xe9f6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const headphonesRoundSound = IconData(0xe9f7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const headphonesRound = IconData(0xe9f8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const headphonesSquareSound = IconData(0xe9f9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const headphonesSquare = IconData(0xe9fa, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mouseCircle = IconData(0xe9fb, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mouseMinimalistic = IconData(0xe9fc, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mouse = IconData(0xe9fd, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const server2 = IconData(0xe9fe, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const serverMinimalistic = IconData(0xe9ff, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const serverPath = IconData(0xea00, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const serverSquareCloud = IconData(0xea01, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const serverSquareUpdate = IconData(0xea02, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const serverSquare = IconData(0xea03, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const server = IconData(0xea04, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const smartphoneRotate2 = IconData(0xea05, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const smartphoneRotateAngle = IconData(0xea06, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const smartphoneRotateOrientation = IconData(0xea07, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const smartphoneVibration = IconData(0xea08, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const tablet = IconData(0xea09, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const gamepadCharge = IconData(0xea0a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const gamepadMinimalistic = IconData(0xea0b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const gamepadNoCharge = IconData(0xea0c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const gamepadOld = IconData(0xea0d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const gamepad = IconData(0xea0e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const iPhone = IconData(0xea0f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const smartphone2 = IconData(0xea10, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const smartphoneUpdate = IconData(0xea11, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const smartphone = IconData(0xea12, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cloudDownload = IconData(0xea13, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cloudSnowfallMinimalistic = IconData(0xea14, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cloudUpload = IconData(0xea15, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cloudyMoon = IconData(0xea16, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const moonFog = IconData(0xea17, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const moonSleep = IconData(0xea18, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const moonStars = IconData(0xea19, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const moon = IconData(0xea1a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const snowflake = IconData(0xea1b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const stars = IconData(0xea1c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sun2 = IconData(0xea1d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sunfog = IconData(0xea1e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sun = IconData(0xea1f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sunrise = IconData(0xea20, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sunset = IconData(0xea21, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const temperature = IconData(0xea22, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const tornadoSmall = IconData(0xea23, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const waterdrops = IconData(0xea24, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const wind = IconData(0xea25, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cloudBoltMinimalistic = IconData(0xea26, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cloudBolt = IconData(0xea27, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cloudCheck = IconData(0xea28, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cloudMinus = IconData(0xea29, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cloudPlus = IconData(0xea2a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cloudRain = IconData(0xea2b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cloudSnowfall = IconData(0xea2c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cloudStorm = IconData(0xea2d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cloudSun2 = IconData(0xea2e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cloudSun = IconData(0xea2f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cloudWaterdrop = IconData(0xea30, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cloudWaterdrops = IconData(0xea31, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cloud = IconData(0xea32, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const clouds = IconData(0xea33, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cloudCross = IconData(0xea34, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const fog = IconData(0xea35, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const tornado = IconData(0xea36, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cloudFile = IconData(0xea37, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const codeFile = IconData(0xea38, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const figmaFile = IconData(0xea39, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const fileCorrupted = IconData(0xea3a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const fileDownload = IconData(0xea3b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const fileLeft = IconData(0xea3c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const fileRight = IconData(0xea3d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const fileSmile = IconData(0xea3e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const zipFile = IconData(0xea3f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const fileCheck = IconData(0xea40, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const fileFavourite = IconData(0xea41, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const fileRemove = IconData(0xea42, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const fileSend = IconData(0xea43, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const fileText = IconData(0xea44, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const file = IconData(0xea45, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const folderOpen = IconData(0xea46, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const addFolder = IconData(0xea47, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const folder2 = IconData(0xea48, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const folderCheck = IconData(0xea49, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const folderCloud = IconData(0xea4a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const folderError = IconData(0xea4b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const folderFavouriteBookmark = IconData(0xea4c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const folderFavouriteStar = IconData(0xea4d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const folderPathConnect = IconData(0xea4e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const folderSecurity = IconData(0xea4f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const folderWithFiles = IconData(0xea50, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const folder = IconData(0xea51, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const moveToFolder = IconData(0xea52, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const removeFolder = IconData(0xea53, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const starFall2 = IconData(0xea54, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const starFallMinimalistic2 = IconData(0xea55, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const starFallMinimalistic = IconData(0xea56, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const starFall = IconData(0xea57, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const starRainbow = IconData(0xea58, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const starRing = IconData(0xea59, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const starRings = IconData(0xea5a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const star = IconData(0xea5b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const starsLine = IconData(0xea5c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const starsMinimalistic = IconData(0xea5d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const stars1 = IconData(0xea5e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const ufo2 = IconData(0xea5f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const ufo3 = IconData(0xea60, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const ufo = IconData(0xea61, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const asteroid = IconData(0xea62, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const atom = IconData(0xea63, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const blackHole2 = IconData(0xea64, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const blackHole3 = IconData(0xea65, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const blackHole = IconData(0xea66, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const earth = IconData(0xea67, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const infinity = IconData(0xea68, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const men = IconData(0xea69, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const planet2 = IconData(0xea6a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const planet3 = IconData(0xea6b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const planet4 = IconData(0xea6c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const planet = IconData(0xea6d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const rocket2 = IconData(0xea6e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const rocket = IconData(0xea6f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const satellite = IconData(0xea70, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const starAngle = IconData(0xea71, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const starCircle = IconData(0xea72, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const women = IconData(0xea73, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const confoundedCircle = IconData(0xea74, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const confoundedSquare = IconData(0xea75, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const emojiFunnyCircle = IconData(0xea76, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const emojiFunnySquare = IconData(0xea77, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const expressionlessCircle = IconData(0xea78, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const expressionlessSquare = IconData(0xea79, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const faceScanCircle = IconData(0xea7a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const faceScanSquare = IconData(0xea7b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const facemaskCircle = IconData(0xea7c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const facemaskSquare = IconData(0xea7d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sadCircle = IconData(0xea7e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sadSquare = IconData(0xea7f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sleepingCircle = IconData(0xea80, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sleepingSquare = IconData(0xea81, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const smileCircle = IconData(0xea82, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const smileSquare = IconData(0xea83, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const stickerCircle = IconData(0xea84, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const stickerSmileCircle2 = IconData(0xea85, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const stickerSmileCircle = IconData(0xea86, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const stickerSmileSquare = IconData(0xea87, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const stickerSquare = IconData(0xea88, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const balls = IconData(0xea89, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const basketball = IconData(0xea8a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bowling = IconData(0xea8b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const football = IconData(0xea8c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const rugby = IconData(0xea8d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const tennis2 = IconData(0xea8e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const tennis = IconData(0xea8f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const volleyball2 = IconData(0xea90, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const volleyball = IconData(0xea91, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bodyShapeMinimalistic = IconData(0xea92, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bodyShape = IconData(0xea93, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const dumbbellLargeMinimalistic = IconData(0xea94, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const dumbbellLarge = IconData(0xea95, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const dumbbellSmall = IconData(0xea96, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const dumbbell = IconData(0xea97, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const dumbbells2 = IconData(0xea98, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const dumbbells = IconData(0xea99, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const golf = IconData(0xea9a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const hikingMinimalistic = IconData(0xea9b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const hikingRound = IconData(0xea9c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const hiking = IconData(0xea9d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const meditationRound = IconData(0xea9e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const meditation = IconData(0xea9f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const ranking = IconData(0xeaa0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const running_2 = IconData(0xeaa1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const runningRound = IconData(0xeaa2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const running = IconData(0xeaa3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const stretchingRound = IconData(0xeaa4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const stretching = IconData(0xeaa5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const swimming = IconData(0xeaa6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const treadmillRound = IconData(0xeaa7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const treadmill = IconData(0xeaa8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const walkingRound = IconData(0xeaa9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const walking = IconData(0xeaaa, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const waterSun = IconData(0xeaab, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const water = IconData(0xeaac, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bicyclingRound = IconData(0xeaad, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bicycling = IconData(0xeaae, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const skateboard = IconData(0xeaaf, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const skateboardingRound = IconData(0xeab0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const skateboarding = IconData(0xeab1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const magnifierBug = IconData(0xeab2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const magnifierZoomIn = IconData(0xeab3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const magnifierZoomOut = IconData(0xeab4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const magnifier = IconData(0xeab5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const minimalisticMagnifierBug = IconData(0xeab6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const minimalisticMagnifierZoomIn = IconData(0xeab7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const minimalisticMagnifierZoomOut = IconData(0xeab8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const minimalisticMagnifier = IconData(0xeab9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundedMagnifierBug = IconData(0xeaba, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundedMagnifierZoomIn = IconData(0xeabb, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundedMagnifierZoomOut = IconData(0xeabc, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundedMagnifier = IconData(0xeabd, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const alarmAdd = IconData(0xeabe, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const alarmPause = IconData(0xeabf, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const alarmRemove = IconData(0xeac0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const alarmTurnOff = IconData(0xeac1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const calendarAdd = IconData(0xeac2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const calendarDate = IconData(0xeac3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const calendarMark = IconData(0xeac4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const calendarMinimalistic = IconData(0xeac5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const calendarSearch = IconData(0xeac6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const calendar = IconData(0xeac7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const history_2 = IconData(0xeac8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const history3 = IconData(0xeac9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const hourglassLine = IconData(0xeaca, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const hourglass = IconData(0xeacb, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const stopwatchPause = IconData(0xeacc, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const stopwatchPlay = IconData(0xeacd, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const stopwatch = IconData(0xeace, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const watchRound = IconData(0xeacf, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const watchSquareMinimalisticCharge = IconData(0xead0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const watchSquareMinimalistic = IconData(0xead1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const watchSquare = IconData(0xead2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const alarmPlay = IconData(0xead3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const alarmSleep = IconData(0xead4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const alarm = IconData(0xead5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const clockCircle = IconData(0xead6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const clockSquare = IconData(0xead7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const history = IconData(0xead8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const listArrowDown = IconData(0xead9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const listArrowUpMinimalistic = IconData(0xeada, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const listArrowUp = IconData(0xeadb, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const listCheckMinimalistic = IconData(0xeadc, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const listCheck = IconData(0xeadd, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const listCrossMinimalistic = IconData(0xeade, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const listCross = IconData(0xeadf, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const listDown = IconData(0xeae0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const listUpMinimalistic = IconData(0xeae1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const listUp = IconData(0xeae2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const list = IconData(0xeae3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const list_1 = IconData(0xeae4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const playlist = IconData(0xeae5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sortByAlphabet = IconData(0xeae6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sortByTime = IconData(0xeae7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sortFromBottomToTop = IconData(0xeae8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sortFromTopToBottom = IconData(0xeae9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const listDownMinimalistic = IconData(0xeaea, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const listHeartMinimalistic = IconData(0xeaeb, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const listHeart = IconData(0xeaec, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const playlistMinimalistic = IconData(0xeaed, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const playlist_2 = IconData(0xeaee, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const playlistMinimalistic2 = IconData(0xeaef, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const playlistMinimalistic3 = IconData(0xeaf0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bill1 = IconData(0xeaf1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const checklistMinimalistic = IconData(0xeaf2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const checklist = IconData(0xeaf3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const listArrowDownMinimalistic = IconData(0xeaf4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const callDroppedRounded = IconData(0xeaf5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const endCallRounded = IconData(0xeaf6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const incomingCallRounded = IconData(0xeaf7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const outgoingCallRounded = IconData(0xeaf8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const phoneCallingRounded = IconData(0xeaf9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const phoneRounded = IconData(0xeafa, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const callCancel = IconData(0xeafb, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const callChatRounded = IconData(0xeafc, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const callChat = IconData(0xeafd, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const callDropped = IconData(0xeafe, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const callMedicineRounded = IconData(0xeaff, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const callMedicine = IconData(0xeb00, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const endCall = IconData(0xeb01, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const incomingCall = IconData(0xeb02, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const outgoingCall = IconData(0xeb03, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const phoneCalling = IconData(0xeb04, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const phone = IconData(0xeb05, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const recordCircle = IconData(0xeb06, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const recordMinimalistic = IconData(0xeb07, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const recordSquare = IconData(0xeb08, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const callCancelRounded = IconData(0xeb09, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const pills_2 = IconData(0xeb0a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const pills_3 = IconData(0xeb0b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const stethoscope = IconData(0xeb0c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const syringe = IconData(0xeb0d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const thermometer = IconData(0xeb0e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const adhesivePlaster2 = IconData(0xeb0f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const adhesivePlaster = IconData(0xeb10, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const boneBroken = IconData(0xeb11, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const boneCrack = IconData(0xeb12, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bone = IconData(0xeb13, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bones = IconData(0xeb14, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const dropper_3 = IconData(0xeb15, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const dropperMinimalistic2 = IconData(0xeb16, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const dropperMinimalistic = IconData(0xeb17, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const health = IconData(0xeb18, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const heartPulse2 = IconData(0xeb19, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const heartPulse = IconData(0xeb1a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const medicalKit = IconData(0xeb1b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const pill = IconData(0xeb1c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const pills = IconData(0xeb1d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const pulse_2 = IconData(0xeb1e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const pulse = IconData(0xeb1f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const testTubeMinimalistic = IconData(0xeb20, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const testTube = IconData(0xeb21, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const virus = IconData(0xeb22, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bacteria = IconData(0xeb23, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const benzeneRing = IconData(0xeb24, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const dna = IconData(0xeb25, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const dropper_2 = IconData(0xeb26, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const dropper = IconData(0xeb27, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const jarOfPills2 = IconData(0xeb28, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const jarOfPills = IconData(0xeb29, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const washingMachine = IconData(0xeb2a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const conditioner_2 = IconData(0xeb2b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const conditioner = IconData(0xeb2c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const remoteController2 = IconData(0xeb2d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const remoteControllerMinimalistic = IconData(0xeb2e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const remoteController = IconData(0xeb2f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const speakerMinimalistic = IconData(0xeb30, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const speaker = IconData(0xeb31, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const volumeKnob = IconData(0xeb32, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const armchair_2 = IconData(0xeb33, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const armchair = IconData(0xeb34, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const barChair = IconData(0xeb35, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bath = IconData(0xeb36, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bed = IconData(0xeb37, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bedsideTable2 = IconData(0xeb38, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bedsideTable3 = IconData(0xeb39, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bedsideTable4 = IconData(0xeb3a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bedsideTable = IconData(0xeb3b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chair_2 = IconData(0xeb3c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chair = IconData(0xeb3d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chandelier = IconData(0xeb3e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const closet_2 = IconData(0xeb3f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const closet = IconData(0xeb40, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const floorLampMinimalistic = IconData(0xeb41, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const floorLamp = IconData(0xeb42, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const fridge = IconData(0xeb43, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const lamp = IconData(0xeb44, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mirror = IconData(0xeb45, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const smartVacuumCleaner_2 = IconData(0xeb46, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const smartVacuumCleaner = IconData(0xeb47, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sofa_2 = IconData(0xeb48, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sofa_3 = IconData(0xeb49, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sofa = IconData(0xeb4a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const trellis = IconData(0xeb4b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const washingMachineMinimalistic = IconData(0xeb4c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const tuning = IconData(0xeb4d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const widget_2 = IconData(0xeb4e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const widget_3 = IconData(0xeb4f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const widget_4 = IconData(0xeb50, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const widget_5 = IconData(0xeb51, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const widget_6 = IconData(0xeb52, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const widgetAdd = IconData(0xeb53, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const widget = IconData(0xeb54, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const settingsMinimalistic = IconData(0xeb55, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const settings = IconData(0xeb56, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const tuning_2 = IconData(0xeb57, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const tuning_3 = IconData(0xeb58, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const tuning_4 = IconData(0xeb59, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const tuningSquare_2 = IconData(0xeb5a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const tuningSquare = IconData(0xeb5b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const usbSquare = IconData(0xeb5c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const usb = IconData(0xeb5d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const wifiRouterMinimalistic = IconData(0xeb5e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const wifiRouterRound = IconData(0xeb5f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const wifiRouter = IconData(0xeb60, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const windowFrame = IconData(0xeb61, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bugMinimalistic = IconData(0xeb62, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bug = IconData(0xeb63, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const command = IconData(0xeb64, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const hashtagChat = IconData(0xeb65, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const hashtagCircle = IconData(0xeb66, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const hashtagSquare = IconData(0xeb67, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const hashtag = IconData(0xeb68, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const structure = IconData(0xeb69, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const code2 = IconData(0xeb6a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const codeCircle = IconData(0xeb6b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const codeSquare = IconData(0xeb6c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const code = IconData(0xeb6d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const programming = IconData(0xeb6e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const screencast_2 = IconData(0xeb6f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const screencast = IconData(0xeb70, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sidebarCode = IconData(0xeb71, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sidebarMinimalistic = IconData(0xeb72, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sidebar = IconData(0xeb73, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const slashCircle = IconData(0xeb74, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const slashSquare = IconData(0xeb75, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const stationMinimalistic = IconData(0xeb76, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const station = IconData(0xeb77, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const translation_2 = IconData(0xeb78, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const translation = IconData(0xeb79, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const usbCircle = IconData(0xeb7a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const textUnderline = IconData(0xeb7b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const text = IconData(0xeb7c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const eraserCircle = IconData(0xeb7d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const eraserSquare = IconData(0xeb7e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const eraser = IconData(0xeb7f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const textItalicSquare = IconData(0xeb80, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const textItalic = IconData(0xeb81, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const textFieldFocus = IconData(0xeb82, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const backspace = IconData(0xeb83, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const linkBrokenMinimalistic = IconData(0xeb84, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const linkBroken = IconData(0xeb85, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const linkCircle = IconData(0xeb86, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const linkMinimalistic_2 = IconData(0xeb87, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const linkMinimalistic = IconData(0xeb88, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const linkRoundAngle = IconData(0xeb89, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const linkRound = IconData(0xeb8a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const linkSquare = IconData(0xeb8b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const link = IconData(0xeb8c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const paragraphSpacing = IconData(0xeb8d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const textBoldCircle = IconData(0xeb8e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const textBoldSquare = IconData(0xeb8f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const textBold = IconData(0xeb90, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const textCircle = IconData(0xeb91, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const textCrossCircle = IconData(0xeb92, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const textCrossSquare = IconData(0xeb93, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const textCross = IconData(0xeb94, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const textField = IconData(0xeb95, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const textItalicCircle = IconData(0xeb96, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const textSelection = IconData(0xeb97, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const textSquare2 = IconData(0xeb98, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const textSquare = IconData(0xeb99, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const textUnderlineCircle = IconData(0xeb9a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const textUnderlineCross = IconData(0xeb9b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const graph = IconData(0xeb9c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const pieChart2 = IconData(0xeb9d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const pieChart3 = IconData(0xeb9e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const pieChart = IconData(0xeb9f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const presentationGraph = IconData(0xeba0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundGraph = IconData(0xeba1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chart_2 = IconData(0xeba2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chartSquare = IconData(0xeba3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chart = IconData(0xeba4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chatSquare_2 = IconData(0xeba5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const courseDown = IconData(0xeba6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const courseUp = IconData(0xeba7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const diagramDown = IconData(0xeba8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const diagramUp = IconData(0xeba9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const graphDownNew = IconData(0xebaa, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const graphDown = IconData(0xebab, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const graphNewUp = IconData(0xebac, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const graphNew = IconData(0xebad, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const graphUp = IconData(0xebae, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const shopMinimalistic = IconData(0xebaf, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const shop = IconData(0xebb0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cartCheck = IconData(0xebb1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cartCross = IconData(0xebb2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cartLarge2 = IconData(0xebb3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cartLarge3 = IconData(0xebb4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cartLargeMinimalistic = IconData(0xebb5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cartLarge = IconData(0xebb6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cartPlus = IconData(0xebb7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bag2 = IconData(0xebb8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bag3 = IconData(0xebb9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bag4 = IconData(0xebba, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bag5 = IconData(0xebbb, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bagCheck = IconData(0xebbc, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bagCross = IconData(0xebbd, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bagHeart = IconData(0xebbe, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bagMusic_2 = IconData(0xebbf, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bagMusic = IconData(0xebc0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bagSmile = IconData(0xebc1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bag = IconData(0xebc2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cart_2 = IconData(0xebc3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cart_3 = IconData(0xebc4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cart_4 = IconData(0xebc5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cart_5 = IconData(0xebc6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cartLarge_4 = IconData(0xebc7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cart = IconData(0xebc8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const shop_2 = IconData(0xebc9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const fire = IconData(0xebca, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const flame = IconData(0xebcb, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const leaf = IconData(0xebcc, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const suitcaseLines = IconData(0xebcd, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const suitcaseTag = IconData(0xebce, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const suitcase = IconData(0xebcf, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bonfire = IconData(0xebd0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const fireMinimalistic = IconData(0xebd1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const fireSquare = IconData(0xebd2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const diploma = IconData(0xebd3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const notebookBookmark = IconData(0xebd4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const notebookMinimalistic = IconData(0xebd5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const notebookSquare = IconData(0xebd6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const notebook = IconData(0xebd7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const plus = IconData(0xebd8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const minus = IconData(0xebd8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareAcademicCap2 = IconData(0xebd9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareAcademicCap = IconData(0xebda, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bookmarkCircle = IconData(0xebdb, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bookmarkOpened = IconData(0xebdc, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bookmarkSquareMinimalistic = IconData(0xebdd, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bookmarkSquare = IconData(0xebde, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bookmark = IconData(0xebdf, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const document = IconData(0xebe0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const passportMinimalistic = IconData(0xebe1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const passport = IconData(0xebe2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const backpack = IconData(0xebe3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const book2 = IconData(0xebe4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bookBookmarkMinimalistic = IconData(0xebe5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bookBookmark = IconData(0xebe6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bookMinimalistic = IconData(0xebe7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const book = IconData(0xebe8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const calculatorMinimalistic = IconData(0xebe9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const calculator = IconData(0xebea, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const caseMinimalistic = IconData(0xebeb, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const caseRoundMinimalistic = IconData(0xebec, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const caseRound = IconData(0xebed, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const case_ = IconData(0xebee, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const diplomaVerified = IconData(0xebef, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mirrorRight = IconData(0xebf0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const pipette = IconData(0xebf1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const radialBlur = IconData(0xebf2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const rulerAngular = IconData(0xebf3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const rulerCrossPen = IconData(0xebf4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const rulerPen = IconData(0xebf5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const ruler = IconData(0xebf6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const threeSquares = IconData(0xebf7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const alignBottom = IconData(0xebf8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const alignHorizontalSpacing = IconData(0xebf9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const alignHorizontalCenter = IconData(0xebfa, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const alignLeft = IconData(0xebfb, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const alignRight = IconData(0xebfc, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const alignTop = IconData(0xebfd, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const alignVerticalCenter = IconData(0xebfe, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const alignVerticalSpacing = IconData(0xebff, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const layersMinimalistic = IconData(0xec00, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const layers = IconData(0xec01, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const paintRoller = IconData(0xec02, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const paletteRound = IconData(0xec03, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const palette = IconData(0xec04, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const palette2 = IconData(0xec05, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const colourTuning = IconData(0xec06, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cropMinimalistic = IconData(0xec07, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const crop = IconData(0xec08, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const filters = IconData(0xec09, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const flipHorizontal = IconData(0xec0a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const flipVertical = IconData(0xec0b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mirrorLeft = IconData(0xec0c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cupHot = IconData(0xec0d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cupPaper = IconData(0xec0e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cup = IconData(0xec0f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const donutBitten = IconData(0xec10, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const donut = IconData(0xec11, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const teaCup = IconData(0xec12, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chefHatHeart = IconData(0xec13, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chefHatMinimalistic = IconData(0xec14, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const corkscrew = IconData(0xec15, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const ladle = IconData(0xec16, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const ovenMittsMinimalistic = IconData(0xec17, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const ovenMitts = IconData(0xec18, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const rollingPin = IconData(0xec19, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const whisk = IconData(0xec1a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const wineglassTriangle = IconData(0xec1b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const wineglass = IconData(0xec1c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bottle = IconData(0xec1d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chefHat = IconData(0xec1e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const medalRibbonsStart = IconData(0xec1f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const medalStar = IconData(0xec20, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const startShine = IconData(0xec21, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const start1 = IconData(0xec22, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const medalStarCircle = IconData(0xec23, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const medalStarSquare = IconData(0xec24, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const dislike = IconData(0xec25, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const heartAngle = IconData(0xec26, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const heartBroken = IconData(0xec27, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const heartLock = IconData(0xec28, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const heartShine = IconData(0xec29, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const heartUnlock = IconData(0xec2a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const heart = IconData(0xec2b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const hearts = IconData(0xec2c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const like = IconData(0xec2d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const medalRibbonStar = IconData(0xec2e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const medalRibbon = IconData(0xec2f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const undoRightRoundSquare = IconData(0xec30, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const undoRightRound = IconData(0xec31, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const undoRightSquare = IconData(0xec32, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const undoRight = IconData(0xec33, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const uploadSquare = IconData(0xec34, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const uploadTwiceSquare = IconData(0xec35, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const arrowToDownLeft = IconData(0xec36, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const arrowToDownRight = IconData(0xec37, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const arrowToTopLeft = IconData(0xec38, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const arrowToTopRight = IconData(0xec39, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const forward_2 = IconData(0xec3a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const reply_2 = IconData(0xec3b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const circleTopDown = IconData(0xec3c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const circleTopUp = IconData(0xec3d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const downloadMinimalistic = IconData(0xec3e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const download = IconData(0xec3f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const exit = IconData(0xec40, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const export = IconData(0xec41, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const forward1 = IconData(0xec42, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const import = IconData(0xec43, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const login_2 = IconData(0xec44, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const login_3 = IconData(0xec45, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const login = IconData(0xec46, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const logout_2 = IconData(0xec47, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const logout_3 = IconData(0xec48, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const logout = IconData(0xec49, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const maximizeSquare2 = IconData(0xec4a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const maximizeSquare3 = IconData(0xec4b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const maximizeSquareMinimalistic = IconData(0xec4c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const maximizeSquare = IconData(0xec4d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const minimizeSquare2 = IconData(0xec4e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const minimizeSquare3 = IconData(0xec4f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const minimizeSquareMinimalistic = IconData(0xec50, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const minimizeSquare = IconData(0xec51, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const reorder = IconData(0xec52, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const reply = IconData(0xec53, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const screenShare = IconData(0xec54, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const uploadMinimalistic = IconData(0xec55, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const upload = IconData(0xec56, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const circleBottomDown = IconData(0xec57, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const circleBottomUp = IconData(0xec58, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const downloadSquare = IconData(0xec59, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const downloadTwiceSquare = IconData(0xec5a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const maximize = IconData(0xec5b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const minimize = IconData(0xec5c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const receiveSquare = IconData(0xec5d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const receiveTwiceSquare = IconData(0xec5e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const scale = IconData(0xec5f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sendSquare = IconData(0xec60, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sendTwiceSquare = IconData(0xec61, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareBottomDown = IconData(0xec62, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareBottomUp = IconData(0xec63, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareTopDown = IconData(0xec64, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareTopUp = IconData(0xec65, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const undoLeftRoundSquare = IconData(0xec66, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const undoLeftRound = IconData(0xec67, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const undoLeftSquare = IconData(0xec68, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const undoLeft = IconData(0xec69, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const notificationRemove = IconData(0xec6a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const notificationUnreadLines = IconData(0xec6b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const notificationUnread = IconData(0xec6c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bellBing = IconData(0xec6d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bellOff = IconData(0xec6e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bell = IconData(0xec6f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const notificationLinesRemove = IconData(0xec70, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const documentText = IconData(0xec71, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const document1 = IconData(0xec72, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const documentsMinimalistic = IconData(0xec73, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const documents = IconData(0xec74, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const notebook1 = IconData(0xec75, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const notesMinimalistic = IconData(0xec76, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const notes = IconData(0xec77, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const archiveCheck = IconData(0xec78, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const archive = IconData(0xec79, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const archiveDownMinimalistic = IconData(0xec7a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const archiveDown = IconData(0xec7b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const archiveMinimalistic = IconData(0xec7c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const archiveUpMinimalistic = IconData(0xec7d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const archiveUp = IconData(0xec7e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const clipboardAdd = IconData(0xec7f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const clipboardCheck = IconData(0xec80, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const clipboardHeart = IconData(0xec81, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const clipboardList = IconData(0xec82, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const clipboardRemove = IconData(0xec83, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const clipboardText = IconData(0xec84, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const clipboard = IconData(0xec85, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const documentAdd = IconData(0xec86, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const documentMedicine = IconData(0xec87, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const lockPassword = IconData(0xec88, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const lockUnlocked = IconData(0xec89, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const lock = IconData(0xec8a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const passwordMinimalistic = IconData(0xec8b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const password = IconData(0xec8c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sirenRounded = IconData(0xec8d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const siren = IconData(0xec8e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const eyeScan = IconData(0xec8f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const objectScan = IconData(0xec90, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const scanner = IconData(0xec91, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const shieldUp = IconData(0xec92, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const codeScan = IconData(0xec93, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const incognito = IconData(0xec94, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const keyMinimalistic2 = IconData(0xec95, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const keyMinimalisticSquare_2 = IconData(0xec96, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const keyMinimalisticSquare_3 = IconData(0xec97, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const keyMinimalisticSquare = IconData(0xec98, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const keyMinimalistic = IconData(0xec99, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const keySquare_2 = IconData(0xec9a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const keySquare = IconData(0xec9b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const key = IconData(0xec9c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const passwordMinimalisticInput = IconData(0xec9d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const qrCode = IconData(0xec9e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const scanner_2 = IconData(0xec9f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const shieldCheck = IconData(0xeca0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const shieldCross = IconData(0xeca1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const shieldKeyholeMinimalistic = IconData(0xeca2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const shieldKeyhole = IconData(0xeca3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const shieldMinimalistic = IconData(0xeca4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const shieldMinus = IconData(0xeca5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const shieldNetwork = IconData(0xeca6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const shieldPlus = IconData(0xeca7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const shieldStar = IconData(0xeca8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const shieldUser = IconData(0xeca9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const shieldWarning = IconData(0xecaa, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const shield = IconData(0xecab, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bombEmoji = IconData(0xecac, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bombMinimalistic = IconData(0xecad, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bomb = IconData(0xecae, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const eyeClosed = IconData(0xecaf, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const eye = IconData(0xecb0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const lockKeyholeMinimalisticUnlocked = IconData(0xecb1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const lockKeyholeMinimalistic = IconData(0xecb2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const lockKeyholeUnlocked = IconData(0xecb3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const lockKeyhole = IconData(0xecb4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const lockPassword_ = IconData(0xecb5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const rewind5SecondsForward = IconData(0xecb6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const soundwaveSquare = IconData(0xecb7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const soundwave = IconData(0xecb8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const videoFrameCut = IconData(0xecb9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const videoFrame = IconData(0xecba, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const volumeLoud = IconData(0xecbb, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const volumeSmall = IconData(0xecbc, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const fullScreenCircle = IconData(0xecbd, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const fullScreenSquare = IconData(0xecbe, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const quitFullScreenCircle = IconData(0xecbf, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const quitFullScreenSquare = IconData(0xecc0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const quitFullScreen = IconData(0xecc1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cameraAdd = IconData(0xecc2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cameraMinimalistic = IconData(0xecc3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cameraRotate = IconData(0xecc4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cameraSquare = IconData(0xecc5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const camera = IconData(0xecc6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const fullScreen = IconData(0xecc7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const galleryCircle = IconData(0xecc8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const galleryFavourite = IconData(0xecc9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const galleryRound = IconData(0xecca, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const pip2 = IconData(0xeccb, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const pip = IconData(0xeccc, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const playbackSpeed = IconData(0xeccd, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const quitPIP = IconData(0xecce, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const reel2 = IconData(0xeccf, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const reel = IconData(0xecd0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const rewindBackCircle = IconData(0xecd1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const rewindForwardCircle = IconData(0xecd2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const shuffle = IconData(0xecd3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const stopCircle = IconData(0xecd4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const stream = IconData(0xecd5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const toPIP = IconData(0xecd6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const videocameraAdd = IconData(0xecd7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const videocameraRecord = IconData(0xecd8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const videocamera = IconData(0xecd9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const clapperboardEdit = IconData(0xecda, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const clapperboardText = IconData(0xecdb, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const galleryCheck = IconData(0xecdc, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const galleryEdit = IconData(0xecdd, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const galleryRemove = IconData(0xecde, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const musicLibrary2 = IconData(0xecdf, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const musicLibrary = IconData(0xece0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const musicNoteSlider2 = IconData(0xece1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const musicNoteSlider = IconData(0xece2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const musicNotes = IconData(0xece3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const panorama = IconData(0xece4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const pauseCircle = IconData(0xece5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const playCircle = IconData(0xece6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const podcast = IconData(0xece7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const rewind10SecondsBack = IconData(0xece8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const rewind10SecondsForward = IconData(0xece9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const rewindBack = IconData(0xecea, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const skipNext = IconData(0xeceb, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const skipPrevious = IconData(0xecec, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const uploadTrack2 = IconData(0xeced, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const uploadTrack = IconData(0xecee, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const videoFrame2 = IconData(0xecef, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const videoFramePlayHorizontal = IconData(0xecf0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const videoFramePlayVertical = IconData(0xecf1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const volumeCross = IconData(0xecf2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const wallpaper = IconData(0xecf3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const clapperboardOpenPlay = IconData(0xecf4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const clapperboardOpen = IconData(0xecf5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const galleryAdd = IconData(0xecf6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const galleryDownload = IconData(0xecf7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const gallerySend = IconData(0xecf8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const galleryWide = IconData(0xecf9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const microphone3 = IconData(0xecfa, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const microphoneLarge = IconData(0xecfb, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const microphone = IconData(0xecfc, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const musicNote2 = IconData(0xecfd, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const musicNote = IconData(0xecfe, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const muted = IconData(0xecff, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const pause = IconData(0xed00, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const playStream = IconData(0xed01, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const play = IconData(0xed02, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const repeatOneMinimalistic = IconData(0xed03, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const rewind15SecondsBack = IconData(0xed04, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const rewind15SecondsForward = IconData(0xed05, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const rewindForward = IconData(0xed06, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const soundwaveCircle = IconData(0xed07, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const stop = IconData(0xed08, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const videoFrameCut2 = IconData(0xed09, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const videoFrameReplace = IconData(0xed0a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const videoLibrary = IconData(0xed0b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const vinylRecord = IconData(0xed0c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const vinyl = IconData(0xed0d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const volume = IconData(0xed0e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const album = IconData(0xed0f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const clapperboardPlay = IconData(0xed10, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const clapperboard = IconData(0xed11, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const galleryMinimalistic = IconData(0xed12, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const gallery = IconData(0xed13, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const library = IconData(0xed14, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const microphone2 = IconData(0xed15, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const musicNote3 = IconData(0xed16, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const musicNote4 = IconData(0xed17, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const recordCircle1 = IconData(0xed18, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const record = IconData(0xed19, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const repeatOne = IconData(0xed1a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const repeat = IconData(0xed1b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const rewind5SecondsBack = IconData(0xed1c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const dangerTriangle = IconData(0xed1d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const danger = IconData(0xed1e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const forbiddenCircle = IconData(0xed1f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const forbidden = IconData(0xed20, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const infoCircle = IconData(0xed21, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const minusCircle = IconData(0xed22, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const questionCircle = IconData(0xed23, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const maskHapply = IconData(0xed24, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const maskSad = IconData(0xed25, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const masks = IconData(0xed26, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mentionCircle = IconData(0xed27, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mentionSquare = IconData(0xed28, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const accessibility = IconData(0xed29, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const body = IconData(0xed2a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const confettiMinimalistic = IconData(0xed2b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const confetti = IconData(0xed2c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cosmetic = IconData(0xed2d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cursorSquare = IconData(0xed2e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cursor = IconData(0xed2f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const delivery = IconData(0xed30, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const ferrisWheel = IconData(0xed31, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const flashlightOn = IconData(0xed32, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const flashlight = IconData(0xed33, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const gift = IconData(0xed34, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const hanger_2 = IconData(0xed35, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const hanger = IconData(0xed36, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const magicStick_2 = IconData(0xed37, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const magicStick_3 = IconData(0xed38, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const magicStick = IconData(0xed39, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const magnetWave = IconData(0xed3a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const magnet = IconData(0xed3b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mirror1 = IconData(0xed3c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const perfume = IconData(0xed3d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const skirt = IconData(0xed3e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sledgehammer = IconData(0xed3f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sleeping = IconData(0xed40, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const tShirt = IconData(0xed41, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const k = IconData(0xed42, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const augmentedReality = IconData(0xed43, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const boxMinimalistic = IconData(0xed44, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const box = IconData(0xed45, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const copyright = IconData(0xed46, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const creativeCommons = IconData(0xed47, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cupFirst = IconData(0xed48, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cupMusic = IconData(0xed49, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cupStar = IconData(0xed4a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cup1 = IconData(0xed4b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const explicit = IconData(0xed4c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const feed = IconData(0xed4d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const filter = IconData(0xed4e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const glasses = IconData(0xed4f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const hamburgerMenu = IconData(0xed50, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const highDefinition = IconData(0xed51, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const highQuality = IconData(0xed52, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const paperBin = IconData(0xed53, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const paw = IconData(0xed54, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const reorder1 = IconData(0xed55, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const scissorsSquare = IconData(0xed56, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const scissors = IconData(0xed57, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sort = IconData(0xed58, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const specialEffects = IconData(0xed59, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const xxx = IconData(0xed5a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const balloon = IconData(0xed5b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const boltCircle = IconData(0xed5c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bolt = IconData(0xed5d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const broom = IconData(0xed5e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cat = IconData(0xed5f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const copy = IconData(0xed60, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const figma = IconData(0xed61, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const flag_2 = IconData(0xed62, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const flag = IconData(0xed63, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const fuel = IconData(0xed64, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const ghostSmile = IconData(0xed65, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const ghost = IconData(0xed66, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const help = IconData(0xed67, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const plate = IconData(0xed68, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const postsCarouselHorizontal = IconData(0xed69, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const postsCarouselVertical = IconData(0xed6a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const power = IconData(0xed6b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const shareCircle = IconData(0xed6c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const share = IconData(0xed6d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const subtitles = IconData(0xed6e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const target = IconData(0xed6f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const trashBin2 = IconData(0xed70, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const umbrella = IconData(0xed71, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const waterdrop = IconData(0xed72, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const winRar = IconData(0xed73, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const batteryChargeMinimalistic = IconData(0xed74, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const batteryCharge = IconData(0xed75, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const batteryFullMinimalistic = IconData(0xed76, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const batteryFull = IconData(0xed77, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const batteryHalfMinimalistic = IconData(0xed78, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const batteryHalf = IconData(0xed79, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const batteryLowMinimalistic = IconData(0xed7a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const batteryLow = IconData(0xed7b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const crownLine = IconData(0xed7c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const crownMinimalistic = IconData(0xed7d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const crownStar = IconData(0xed7e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const crown = IconData(0xed7f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const database = IconData(0xed80, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const homeWiFiAngle = IconData(0xed81, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const pinCircle = IconData(0xed82, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const pinList = IconData(0xed83, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const pin = IconData(0xed84, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sliderHorizontal = IconData(0xed85, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sliderMinimalisticHorizontal = IconData(0xed86, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sliderVerticalMinimalistic = IconData(0xed87, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sliderVertical = IconData(0xed88, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const smartHomeAngle = IconData(0xed89, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const trafficEconomy = IconData(0xed8a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const traffic = IconData(0xed8b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const trashBinMinimalistic_2 = IconData(0xed8c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const trashBinMinimalistic = IconData(0xed8d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const trashBinTrash = IconData(0xed8e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const addSquare = IconData(0xed8f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const checkSquare = IconData(0xed90, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const closeSquare = IconData(0xed91, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const dangerSquare = IconData(0xed92, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const home2 = IconData(0xed93, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const homeAddAngle = IconData(0xed94, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const homeAdd = IconData(0xed95, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const homeAngle_2 = IconData(0xed96, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const homeAngle = IconData(0xed97, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const homeSmileAngle = IconData(0xed98, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const homeSmile = IconData(0xed99, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const homeWiFi = IconData(0xed9a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const home = IconData(0xed9b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const infoSquare = IconData(0xed9c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const menuDotsCircle = IconData(0xed9d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const menuDotsSquare = IconData(0xed9e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const menuDots = IconData(0xed9f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const minusSquare = IconData(0xeda0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const questionSquare = IconData(0xeda1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const revote = IconData(0xeda2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const smartHome = IconData(0xeda3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const addCircle = IconData(0xeda4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const checkCircle = IconData(0xeda5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const closeCircle = IconData(0xeda6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const dangerCircle = IconData(0xeda7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const userPlus = IconData(0xeda8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const userRounded = IconData(0xeda9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const userSpeakRounded = IconData(0xedaa, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const user = IconData(0xedab, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const usersGroupRounded = IconData(0xedac, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const usersGroupTwoRounded = IconData(0xedad, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const userHandUp = IconData(0xedae, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const userHands = IconData(0xedaf, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const userHeart = IconData(0xedb0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const userSpeak = IconData(0xedb1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const userBlockRounded = IconData(0xedb2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const userBlock = IconData(0xedb3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const userCheckRounded = IconData(0xedb4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const userCheck = IconData(0xedb5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const userCircle = IconData(0xedb6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const userCrossRounded = IconData(0xedb7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const userCross = IconData(0xedb8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const userHeartRounded = IconData(0xedb9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const userId = IconData(0xedba, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const userMinusRounded = IconData(0xedbb, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const userMinus = IconData(0xedbc, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const userPlusRounded = IconData(0xedbd, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const handPills = IconData(0xedbe, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const handShake = IconData(0xedbf, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const handStars = IconData(0xedc0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const handHeart = IconData(0xedc1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const handMoney = IconData(0xedc2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const garage = IconData(0xedc3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const home1 = IconData(0xedc4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const hospital = IconData(0xedc5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const buildings_2 = IconData(0xedc6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const buildings_3 = IconData(0xedc7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const buildings = IconData(0xedc8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const city = IconData(0xedc9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const suspension = IconData(0xedca, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const transmissionCircle = IconData(0xedcb, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const transmissionSquare = IconData(0xedcc, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const transmission = IconData(0xedcd, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bus = IconData(0xedce, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const kickScooter = IconData(0xedcf, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const scooter = IconData(0xedd0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const speedometerLow = IconData(0xedd1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const speedometerMax = IconData(0xedd2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const speedometerMiddle = IconData(0xedd3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const tram = IconData(0xedd4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const wheelAngle = IconData(0xedd5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const wheel = IconData(0xedd6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const accumulator = IconData(0xedd7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const electricRefueling = IconData(0xedd8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const gasStation = IconData(0xedd9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const shockAbsorber = IconData(0xedda, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const suspensionBolt = IconData(0xeddb, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const suspensionCross = IconData(0xeddc, fontFamily: _fontFamily, fontPackage: 'solar_icons');
 }

--- a/lib/src/solar_icons_data.dart
+++ b/lib/src/solar_icons_data.dart
@@ -1,6 +1,0 @@
-import 'package:flutter/material.dart';
-
-class SolarIconsData extends IconData {
-  const SolarIconsData(int codePoint, {required String fontFamily})
-      : super(codePoint, fontFamily: fontFamily, fontPackage: 'solar_icons');
-}

--- a/lib/src/solar_icons_outline.dart
+++ b/lib/src/solar_icons_outline.dart
@@ -1,2502 +1,1255 @@
-import 'solar_icons_data.dart';
+import 'package:flutter/widgets.dart';
 
 class SolarIconsOutline {
   SolarIconsOutline._();
 
-  static const String _fontFamily = 'SolarIconsOutline';
+  static const _fontFamily = 'SolarIconsOutline';
 
-  static const SolarIconsData forward =
-      SolarIconsData(0xe900, fontFamily: _fontFamily);
-  static const SolarIconsData inbox =
-      SolarIconsData(0xe901, fontFamily: _fontFamily);
-  static const SolarIconsData letterOpened =
-      SolarIconsData(0xe902, fontFamily: _fontFamily);
-  static const SolarIconsData letterUnread =
-      SolarIconsData(0xe903, fontFamily: _fontFamily);
-  static const SolarIconsData letter =
-      SolarIconsData(0xe904, fontFamily: _fontFamily);
-  static const SolarIconsData mailbox =
-      SolarIconsData(0xe905, fontFamily: _fontFamily);
-  static const SolarIconsData multipleForwardLeft =
-      SolarIconsData(0xe906, fontFamily: _fontFamily);
-  static const SolarIconsData multipleForwardRight =
-      SolarIconsData(0xe907, fontFamily: _fontFamily);
-  static const SolarIconsData paperclip2 =
-      SolarIconsData(0xe908, fontFamily: _fontFamily);
-  static const SolarIconsData paperclipRounded2 =
-      SolarIconsData(0xe909, fontFamily: _fontFamily);
-  static const SolarIconsData paperclipRounded =
-      SolarIconsData(0xe90a, fontFamily: _fontFamily);
-  static const SolarIconsData paperclip =
-      SolarIconsData(0xe90b, fontFamily: _fontFamily);
-  static const SolarIconsData pen2 =
-      SolarIconsData(0xe90c, fontFamily: _fontFamily);
-  static const SolarIconsData penNewRound =
-      SolarIconsData(0xe90d, fontFamily: _fontFamily);
-  static const SolarIconsData penNewSquare =
-      SolarIconsData(0xe90e, fontFamily: _fontFamily);
-  static const SolarIconsData pen =
-      SolarIconsData(0xe90f, fontFamily: _fontFamily);
-  static const SolarIconsData plain2 =
-      SolarIconsData(0xe910, fontFamily: _fontFamily);
-  static const SolarIconsData plain3 =
-      SolarIconsData(0xe911, fontFamily: _fontFamily);
-  static const SolarIconsData plain =
-      SolarIconsData(0xe912, fontFamily: _fontFamily);
-  static const SolarIconsData squareForward =
-      SolarIconsData(0xe913, fontFamily: _fontFamily);
-  static const SolarIconsData squareShareLine =
-      SolarIconsData(0xe914, fontFamily: _fontFamily);
-  static const SolarIconsData chatDots =
-      SolarIconsData(0xe915, fontFamily: _fontFamily);
-  static const SolarIconsData chatLine =
-      SolarIconsData(0xe916, fontFamily: _fontFamily);
-  static const SolarIconsData chatRoundCall =
-      SolarIconsData(0xe917, fontFamily: _fontFamily);
-  static const SolarIconsData chatRoundCheck =
-      SolarIconsData(0xe918, fontFamily: _fontFamily);
-  static const SolarIconsData chatRoundDots =
-      SolarIconsData(0xe919, fontFamily: _fontFamily);
-  static const SolarIconsData chatRoundLike =
-      SolarIconsData(0xe91a, fontFamily: _fontFamily);
-  static const SolarIconsData chatRoundLine =
-      SolarIconsData(0xe91b, fontFamily: _fontFamily);
-  static const SolarIconsData chatRoundMoney =
-      SolarIconsData(0xe91c, fontFamily: _fontFamily);
-  static const SolarIconsData chatRoundUnread =
-      SolarIconsData(0xe91d, fontFamily: _fontFamily);
-  static const SolarIconsData chatRoundVideo =
-      SolarIconsData(0xe91e, fontFamily: _fontFamily);
-  static const SolarIconsData chatRound =
-      SolarIconsData(0xe91f, fontFamily: _fontFamily);
-  static const SolarIconsData chatSquareArrow =
-      SolarIconsData(0xe920, fontFamily: _fontFamily);
-  static const SolarIconsData chatSquareCall =
-      SolarIconsData(0xe921, fontFamily: _fontFamily);
-  static const SolarIconsData chatSquareCheck =
-      SolarIconsData(0xe922, fontFamily: _fontFamily);
-  static const SolarIconsData chatSquareCode =
-      SolarIconsData(0xe923, fontFamily: _fontFamily);
-  static const SolarIconsData chatSquareLike =
-      SolarIconsData(0xe924, fontFamily: _fontFamily);
-  static const SolarIconsData chatSquare =
-      SolarIconsData(0xe925, fontFamily: _fontFamily);
-  static const SolarIconsData chatUnread =
-      SolarIconsData(0xe926, fontFamily: _fontFamily);
-  static const SolarIconsData chatRead =
-      SolarIconsData(0xe927, fontFamily: _fontFamily);
-  static const SolarIconsData dialog2 =
-      SolarIconsData(0xe928, fontFamily: _fontFamily);
-  static const SolarIconsData dialog =
-      SolarIconsData(0xe929, fontFamily: _fontFamily);
-  static const SolarIconsData inboxArchive =
-      SolarIconsData(0xe92a, fontFamily: _fontFamily);
-  static const SolarIconsData inboxIn =
-      SolarIconsData(0xe92b, fontFamily: _fontFamily);
-  static const SolarIconsData inboxLine =
-      SolarIconsData(0xe92c, fontFamily: _fontFamily);
-  static const SolarIconsData inboxOut =
-      SolarIconsData(0xe92d, fontFamily: _fontFamily);
-  static const SolarIconsData inboxUnread =
-      SolarIconsData(0xe92e, fontFamily: _fontFamily);
-  static const SolarIconsData unread =
-      SolarIconsData(0xe92f, fontFamily: _fontFamily);
-  static const SolarIconsData refreshCircle =
-      SolarIconsData(0xe930, fontFamily: _fontFamily);
-  static const SolarIconsData refreshSquare =
-      SolarIconsData(0xe931, fontFamily: _fontFamily);
-  static const SolarIconsData restartCircle =
-      SolarIconsData(0xe932, fontFamily: _fontFamily);
-  static const SolarIconsData restartSquare =
-      SolarIconsData(0xe933, fontFamily: _fontFamily);
-  static const SolarIconsData altArrowDown =
-      SolarIconsData(0xe934, fontFamily: _fontFamily);
-  static const SolarIconsData altArrowLeft =
-      SolarIconsData(0xe935, fontFamily: _fontFamily);
-  static const SolarIconsData altArrowRight =
-      SolarIconsData(0xe936, fontFamily: _fontFamily);
-  static const SolarIconsData altArrowUp =
-      SolarIconsData(0xe937, fontFamily: _fontFamily);
-  static const SolarIconsData arrowDown =
-      SolarIconsData(0xe938, fontFamily: _fontFamily);
-  static const SolarIconsData arrowLeftDown =
-      SolarIconsData(0xe939, fontFamily: _fontFamily);
-  static const SolarIconsData arrowLeftUp =
-      SolarIconsData(0xe93a, fontFamily: _fontFamily);
-  static const SolarIconsData arrowLeft =
-      SolarIconsData(0xe93b, fontFamily: _fontFamily);
-  static const SolarIconsData arrowRightDown =
-      SolarIconsData(0xe93c, fontFamily: _fontFamily);
-  static const SolarIconsData arrowRightUp =
-      SolarIconsData(0xe93d, fontFamily: _fontFamily);
-  static const SolarIconsData arrowRight =
-      SolarIconsData(0xe93e, fontFamily: _fontFamily);
-  static const SolarIconsData arrowUp =
-      SolarIconsData(0xe93f, fontFamily: _fontFamily);
-  static const SolarIconsData doubleAltArrowDown =
-      SolarIconsData(0xe940, fontFamily: _fontFamily);
-  static const SolarIconsData doubleAltArrowLeft =
-      SolarIconsData(0xe941, fontFamily: _fontFamily);
-  static const SolarIconsData doubleAltArrowRight =
-      SolarIconsData(0xe942, fontFamily: _fontFamily);
-  static const SolarIconsData doubleAltArrowUp =
-      SolarIconsData(0xe943, fontFamily: _fontFamily);
-  static const SolarIconsData refresh =
-      SolarIconsData(0xe944, fontFamily: _fontFamily);
-  static const SolarIconsData restart =
-      SolarIconsData(0xe945, fontFamily: _fontFamily);
-  static const SolarIconsData roundAltArrowDown =
-      SolarIconsData(0xe946, fontFamily: _fontFamily);
-  static const SolarIconsData roundAltArrowUp =
-      SolarIconsData(0xe947, fontFamily: _fontFamily);
-  static const SolarIconsData roundDoubleAltArrowLeft =
-      SolarIconsData(0xe948, fontFamily: _fontFamily);
-  static const SolarIconsData roundDoubleAltArrowRight =
-      SolarIconsData(0xe949, fontFamily: _fontFamily);
-  static const SolarIconsData roundDoubleAltArrowUp =
-      SolarIconsData(0xe94a, fontFamily: _fontFamily);
-  static const SolarIconsData roundSortHorizontal =
-      SolarIconsData(0xe94b, fontFamily: _fontFamily);
-  static const SolarIconsData roundTransferDiagonal =
-      SolarIconsData(0xe94c, fontFamily: _fontFamily);
-  static const SolarIconsData sortHorizontal =
-      SolarIconsData(0xe94d, fontFamily: _fontFamily);
-  static const SolarIconsData sortVertical =
-      SolarIconsData(0xe94e, fontFamily: _fontFamily);
-  static const SolarIconsData transferHorizontal =
-      SolarIconsData(0xe94f, fontFamily: _fontFamily);
-  static const SolarIconsData transferVertical =
-      SolarIconsData(0xe950, fontFamily: _fontFamily);
-  static const SolarIconsData roundAltArrowLeft =
-      SolarIconsData(0xe951, fontFamily: _fontFamily);
-  static const SolarIconsData roundAltArrowRight =
-      SolarIconsData(0xe952, fontFamily: _fontFamily);
-  static const SolarIconsData roundArrowDown =
-      SolarIconsData(0xe953, fontFamily: _fontFamily);
-  static const SolarIconsData roundArrowLeftDown =
-      SolarIconsData(0xe954, fontFamily: _fontFamily);
-  static const SolarIconsData roundArrowLeftUp =
-      SolarIconsData(0xe955, fontFamily: _fontFamily);
-  static const SolarIconsData roundArrowLeft =
-      SolarIconsData(0xe956, fontFamily: _fontFamily);
-  static const SolarIconsData roundArrowRightDown =
-      SolarIconsData(0xe957, fontFamily: _fontFamily);
-  static const SolarIconsData roundArrowRightUp =
-      SolarIconsData(0xe958, fontFamily: _fontFamily);
-  static const SolarIconsData roundArrowRight =
-      SolarIconsData(0xe959, fontFamily: _fontFamily);
-  static const SolarIconsData roundArrowUp =
-      SolarIconsData(0xe95a, fontFamily: _fontFamily);
-  static const SolarIconsData roundDoubleAltArrowDown =
-      SolarIconsData(0xe95b, fontFamily: _fontFamily);
-  static const SolarIconsData roundSortVertical =
-      SolarIconsData(0xe95c, fontFamily: _fontFamily);
-  static const SolarIconsData roundTransferHorizontal =
-      SolarIconsData(0xe95d, fontFamily: _fontFamily);
-  static const SolarIconsData roundTransferVertical =
-      SolarIconsData(0xe95e, fontFamily: _fontFamily);
-  static const SolarIconsData squareAltArrowDown =
-      SolarIconsData(0xe95f, fontFamily: _fontFamily);
-  static const SolarIconsData squareAltArrowUp =
-      SolarIconsData(0xe960, fontFamily: _fontFamily);
-  static const SolarIconsData squareArrowDown =
-      SolarIconsData(0xe961, fontFamily: _fontFamily);
-  static const SolarIconsData squareArrowLeftDown =
-      SolarIconsData(0xe962, fontFamily: _fontFamily);
-  static const SolarIconsData squareArrowLeftUp =
-      SolarIconsData(0xe963, fontFamily: _fontFamily);
-  static const SolarIconsData squareArrowLeft =
-      SolarIconsData(0xe964, fontFamily: _fontFamily);
-  static const SolarIconsData squareArrowRightDown =
-      SolarIconsData(0xe965, fontFamily: _fontFamily);
-  static const SolarIconsData squareArrowRightUp =
-      SolarIconsData(0xe966, fontFamily: _fontFamily);
-  static const SolarIconsData squareArrowRight =
-      SolarIconsData(0xe967, fontFamily: _fontFamily);
-  static const SolarIconsData squareArrowUp =
-      SolarIconsData(0xe968, fontFamily: _fontFamily);
-  static const SolarIconsData squareSortHorizontal =
-      SolarIconsData(0xe969, fontFamily: _fontFamily);
-  static const SolarIconsData squareSortVertical =
-      SolarIconsData(0xe96a, fontFamily: _fontFamily);
-  static const SolarIconsData squareTransferHorizontal =
-      SolarIconsData(0xe96b, fontFamily: _fontFamily);
-  static const SolarIconsData squareTransferVertical =
-      SolarIconsData(0xe96c, fontFamily: _fontFamily);
-  static const SolarIconsData squareAltArrowLeft =
-      SolarIconsData(0xe96d, fontFamily: _fontFamily);
-  static const SolarIconsData squareAltArrowRight =
-      SolarIconsData(0xe96e, fontFamily: _fontFamily);
-  static const SolarIconsData squareDoubleAltArrowRight =
-      SolarIconsData(0xe96f, fontFamily: _fontFamily);
-  static const SolarIconsData squareDoubleAltArrowDown =
-      SolarIconsData(0xe970, fontFamily: _fontFamily);
-  static const SolarIconsData squareDoubleAltArrowLeft =
-      SolarIconsData(0xe971, fontFamily: _fontFamily);
-  static const SolarIconsData squareDoubleAltArrowUp =
-      SolarIconsData(0xe972, fontFamily: _fontFamily);
-  static const SolarIconsData compassBig =
-      SolarIconsData(0xe973, fontFamily: _fontFamily);
-  static const SolarIconsData globus =
-      SolarIconsData(0xe974, fontFamily: _fontFamily);
-  static const SolarIconsData gps =
-      SolarIconsData(0xe975, fontFamily: _fontFamily);
-  static const SolarIconsData pointOnMapPerspective =
-      SolarIconsData(0xe976, fontFamily: _fontFamily);
-  static const SolarIconsData radar2 =
-      SolarIconsData(0xe977, fontFamily: _fontFamily);
-  static const SolarIconsData radar =
-      SolarIconsData(0xe978, fontFamily: _fontFamily);
-  static const SolarIconsData routing2 =
-      SolarIconsData(0xe979, fontFamily: _fontFamily);
-  static const SolarIconsData routing3 =
-      SolarIconsData(0xe97a, fontFamily: _fontFamily);
-  static const SolarIconsData routing =
-      SolarIconsData(0xe97b, fontFamily: _fontFamily);
-  static const SolarIconsData streetsMapPoint =
-      SolarIconsData(0xe97c, fontFamily: _fontFamily);
-  static const SolarIconsData streetsNavigation =
-      SolarIconsData(0xe97d, fontFamily: _fontFamily);
-  static const SolarIconsData streets =
-      SolarIconsData(0xe97e, fontFamily: _fontFamily);
-  static const SolarIconsData branchingPathsDown =
-      SolarIconsData(0xe97f, fontFamily: _fontFamily);
-  static const SolarIconsData branchingPathsUp =
-      SolarIconsData(0xe980, fontFamily: _fontFamily);
-  static const SolarIconsData compassSquare =
-      SolarIconsData(0xe981, fontFamily: _fontFamily);
-  static const SolarIconsData compass =
-      SolarIconsData(0xe982, fontFamily: _fontFamily);
-  static const SolarIconsData global =
-      SolarIconsData(0xe983, fontFamily: _fontFamily);
-  static const SolarIconsData mapArrowDown =
-      SolarIconsData(0xe984, fontFamily: _fontFamily);
-  static const SolarIconsData mapArrowLeft =
-      SolarIconsData(0xe985, fontFamily: _fontFamily);
-  static const SolarIconsData mapArrowRight =
-      SolarIconsData(0xe986, fontFamily: _fontFamily);
-  static const SolarIconsData mapArrowSquare =
-      SolarIconsData(0xe987, fontFamily: _fontFamily);
-  static const SolarIconsData mapArrowUp =
-      SolarIconsData(0xe988, fontFamily: _fontFamily);
-  static const SolarIconsData mapPointAdd =
-      SolarIconsData(0xe989, fontFamily: _fontFamily);
-  static const SolarIconsData mapPointFavourite =
-      SolarIconsData(0xe98a, fontFamily: _fontFamily);
-  static const SolarIconsData mapPointHospital =
-      SolarIconsData(0xe98b, fontFamily: _fontFamily);
-  static const SolarIconsData mapPointRemove =
-      SolarIconsData(0xe98c, fontFamily: _fontFamily);
-  static const SolarIconsData mapPointRotate =
-      SolarIconsData(0xe98d, fontFamily: _fontFamily);
-  static const SolarIconsData mapPointSchool =
-      SolarIconsData(0xe98e, fontFamily: _fontFamily);
-  static const SolarIconsData mapPointSearch =
-      SolarIconsData(0xe98f, fontFamily: _fontFamily);
-  static const SolarIconsData mapPointWave =
-      SolarIconsData(0xe990, fontFamily: _fontFamily);
-  static const SolarIconsData mapPoint =
-      SolarIconsData(0xe991, fontFamily: _fontFamily);
-  static const SolarIconsData map =
-      SolarIconsData(0xe992, fontFamily: _fontFamily);
-  static const SolarIconsData peopleNearby =
-      SolarIconsData(0xe993, fontFamily: _fontFamily);
-  static const SolarIconsData pointOnMap =
-      SolarIconsData(0xe994, fontFamily: _fontFamily);
-  static const SolarIconsData route =
-      SolarIconsData(0xe995, fontFamily: _fontFamily);
-  static const SolarIconsData signpost2 =
-      SolarIconsData(0xe996, fontFamily: _fontFamily);
-  static const SolarIconsData signpost =
-      SolarIconsData(0xe997, fontFamily: _fontFamily);
-  static const SolarIconsData fullScreenCircle =
-      SolarIconsData(0xe998, fontFamily: _fontFamily);
-  static const SolarIconsData fullScreenSquare =
-      SolarIconsData(0xe999, fontFamily: _fontFamily);
-  static const SolarIconsData cameraAdd =
-      SolarIconsData(0xe99a, fontFamily: _fontFamily);
-  static const SolarIconsData cameraMinimalistic =
-      SolarIconsData(0xe99b, fontFamily: _fontFamily);
-  static const SolarIconsData cameraRotate =
-      SolarIconsData(0xe99c, fontFamily: _fontFamily);
-  static const SolarIconsData cameraSquare =
-      SolarIconsData(0xe99d, fontFamily: _fontFamily);
-  static const SolarIconsData camera =
-      SolarIconsData(0xe99e, fontFamily: _fontFamily);
-  static const SolarIconsData fullScreen =
-      SolarIconsData(0xe99f, fontFamily: _fontFamily);
-  static const SolarIconsData galleryCircle =
-      SolarIconsData(0xe9a0, fontFamily: _fontFamily);
-  static const SolarIconsData galleryFavourite =
-      SolarIconsData(0xe9a1, fontFamily: _fontFamily);
-  static const SolarIconsData galleryRound =
-      SolarIconsData(0xe9a2, fontFamily: _fontFamily);
-  static const SolarIconsData pauseCircle =
-      SolarIconsData(0xe9a3, fontFamily: _fontFamily);
-  static const SolarIconsData pip2 =
-      SolarIconsData(0xe9a4, fontFamily: _fontFamily);
-  static const SolarIconsData pip =
-      SolarIconsData(0xe9a5, fontFamily: _fontFamily);
-  static const SolarIconsData playbackSpeed =
-      SolarIconsData(0xe9a6, fontFamily: _fontFamily);
-  static const SolarIconsData quitFullScreenCircle =
-      SolarIconsData(0xe9a7, fontFamily: _fontFamily);
-  static const SolarIconsData quitFullScreenSquare =
-      SolarIconsData(0xe9a8, fontFamily: _fontFamily);
-  static const SolarIconsData quitFullScreen =
-      SolarIconsData(0xe9a9, fontFamily: _fontFamily);
-  static const SolarIconsData quitPIP =
-      SolarIconsData(0xe9aa, fontFamily: _fontFamily);
-  static const SolarIconsData reel2 =
-      SolarIconsData(0xe9ab, fontFamily: _fontFamily);
-  static const SolarIconsData reel =
-      SolarIconsData(0xe9ac, fontFamily: _fontFamily);
-  static const SolarIconsData rewindBackCircle =
-      SolarIconsData(0xe9ad, fontFamily: _fontFamily);
-  static const SolarIconsData rewindForwardCircle =
-      SolarIconsData(0xe9ae, fontFamily: _fontFamily);
-  static const SolarIconsData shuffle =
-      SolarIconsData(0xe9af, fontFamily: _fontFamily);
-  static const SolarIconsData stopCircle =
-      SolarIconsData(0xe9b0, fontFamily: _fontFamily);
-  static const SolarIconsData stream =
-      SolarIconsData(0xe9b1, fontFamily: _fontFamily);
-  static const SolarIconsData toPIP =
-      SolarIconsData(0xe9b2, fontFamily: _fontFamily);
-  static const SolarIconsData videocameraAdd =
-      SolarIconsData(0xe9b3, fontFamily: _fontFamily);
-  static const SolarIconsData videocameraRecord =
-      SolarIconsData(0xe9b4, fontFamily: _fontFamily);
-  static const SolarIconsData videocamera =
-      SolarIconsData(0xe9b5, fontFamily: _fontFamily);
-  static const SolarIconsData clapperboardEdit =
-      SolarIconsData(0xe9b6, fontFamily: _fontFamily);
-  static const SolarIconsData clapperboardText =
-      SolarIconsData(0xe9b7, fontFamily: _fontFamily);
-  static const SolarIconsData galleryAdd =
-      SolarIconsData(0xe9b8, fontFamily: _fontFamily);
-  static const SolarIconsData galleryCheck =
-      SolarIconsData(0xe9b9, fontFamily: _fontFamily);
-  static const SolarIconsData galleryEdit =
-      SolarIconsData(0xe9ba, fontFamily: _fontFamily);
-  static const SolarIconsData galleryRemove =
-      SolarIconsData(0xe9bb, fontFamily: _fontFamily);
-  static const SolarIconsData gallerySend =
-      SolarIconsData(0xe9bc, fontFamily: _fontFamily);
-  static const SolarIconsData microphoneLarge =
-      SolarIconsData(0xe9bd, fontFamily: _fontFamily);
-  static const SolarIconsData musicLibrary2 =
-      SolarIconsData(0xe9be, fontFamily: _fontFamily);
-  static const SolarIconsData musicLibrary =
-      SolarIconsData(0xe9bf, fontFamily: _fontFamily);
-  static const SolarIconsData musicNoteSlider2 =
-      SolarIconsData(0xe9c0, fontFamily: _fontFamily);
-  static const SolarIconsData musicNoteSlider =
-      SolarIconsData(0xe9c1, fontFamily: _fontFamily);
-  static const SolarIconsData musicNotes =
-      SolarIconsData(0xe9c2, fontFamily: _fontFamily);
-  static const SolarIconsData panorama =
-      SolarIconsData(0xe9c3, fontFamily: _fontFamily);
-  static const SolarIconsData playCircle =
-      SolarIconsData(0xe9c4, fontFamily: _fontFamily);
-  static const SolarIconsData podcast =
-      SolarIconsData(0xe9c5, fontFamily: _fontFamily);
-  static const SolarIconsData rewind10SecondsBack =
-      SolarIconsData(0xe9c6, fontFamily: _fontFamily);
-  static const SolarIconsData rewind10SecondsForward =
-      SolarIconsData(0xe9c7, fontFamily: _fontFamily);
-  static const SolarIconsData rewindBack =
-      SolarIconsData(0xe9c8, fontFamily: _fontFamily);
-  static const SolarIconsData rewindForward =
-      SolarIconsData(0xe9c9, fontFamily: _fontFamily);
-  static const SolarIconsData skipNext =
-      SolarIconsData(0xe9ca, fontFamily: _fontFamily);
-  static const SolarIconsData skipPrevious =
-      SolarIconsData(0xe9cb, fontFamily: _fontFamily);
-  static const SolarIconsData uploadTrack2 =
-      SolarIconsData(0xe9cc, fontFamily: _fontFamily);
-  static const SolarIconsData uploadTrack =
-      SolarIconsData(0xe9cd, fontFamily: _fontFamily);
-  static const SolarIconsData videoFrame2 =
-      SolarIconsData(0xe9ce, fontFamily: _fontFamily);
-  static const SolarIconsData videoFramePlayHorizontal =
-      SolarIconsData(0xe9cf, fontFamily: _fontFamily);
-  static const SolarIconsData videoFramePlayVertical =
-      SolarIconsData(0xe9d0, fontFamily: _fontFamily);
-  static const SolarIconsData volumeCross =
-      SolarIconsData(0xe9d1, fontFamily: _fontFamily);
-  static const SolarIconsData wallpaper =
-      SolarIconsData(0xe9d2, fontFamily: _fontFamily);
-  static const SolarIconsData album =
-      SolarIconsData(0xe9d3, fontFamily: _fontFamily);
-  static const SolarIconsData clapperboardOpenPlay =
-      SolarIconsData(0xe9d4, fontFamily: _fontFamily);
-  static const SolarIconsData clapperboardOpen =
-      SolarIconsData(0xe9d5, fontFamily: _fontFamily);
-  static const SolarIconsData galleryDownload =
-      SolarIconsData(0xe9d6, fontFamily: _fontFamily);
-  static const SolarIconsData galleryMinimalistic =
-      SolarIconsData(0xe9d7, fontFamily: _fontFamily);
-  static const SolarIconsData galleryWide =
-      SolarIconsData(0xe9d8, fontFamily: _fontFamily);
-  static const SolarIconsData microphone3 =
-      SolarIconsData(0xe9d9, fontFamily: _fontFamily);
-  static const SolarIconsData microphone =
-      SolarIconsData(0xe9da, fontFamily: _fontFamily);
-  static const SolarIconsData musicNote2 =
-      SolarIconsData(0xe9db, fontFamily: _fontFamily);
-  static const SolarIconsData musicNote3 =
-      SolarIconsData(0xe9dc, fontFamily: _fontFamily);
-  static const SolarIconsData musicNote =
-      SolarIconsData(0xe9dd, fontFamily: _fontFamily);
-  static const SolarIconsData muted =
-      SolarIconsData(0xe9de, fontFamily: _fontFamily);
-  static const SolarIconsData pause =
-      SolarIconsData(0xe9df, fontFamily: _fontFamily);
-  static const SolarIconsData playStream =
-      SolarIconsData(0xe9e0, fontFamily: _fontFamily);
-  static const SolarIconsData play =
-      SolarIconsData(0xe9e1, fontFamily: _fontFamily);
-  static const SolarIconsData repeatOneMinimalistic =
-      SolarIconsData(0xe9e2, fontFamily: _fontFamily);
-  static const SolarIconsData repeatOne =
-      SolarIconsData(0xe9e3, fontFamily: _fontFamily);
-  static const SolarIconsData rewind15SecondsBack =
-      SolarIconsData(0xe9e4, fontFamily: _fontFamily);
-  static const SolarIconsData rewind15SecondsForward =
-      SolarIconsData(0xe9e5, fontFamily: _fontFamily);
-  static const SolarIconsData soundwaveCircle =
-      SolarIconsData(0xe9e6, fontFamily: _fontFamily);
-  static const SolarIconsData soundwaveSquare =
-      SolarIconsData(0xe9e7, fontFamily: _fontFamily);
-  static const SolarIconsData stop =
-      SolarIconsData(0xe9e8, fontFamily: _fontFamily);
-  static const SolarIconsData videoFrameCut2 =
-      SolarIconsData(0xe9e9, fontFamily: _fontFamily);
-  static const SolarIconsData videoFrameReplace =
-      SolarIconsData(0xe9ea, fontFamily: _fontFamily);
-  static const SolarIconsData videoLibrary =
-      SolarIconsData(0xe9eb, fontFamily: _fontFamily);
-  static const SolarIconsData vinylRecord =
-      SolarIconsData(0xe9ec, fontFamily: _fontFamily);
-  static const SolarIconsData vinyl =
-      SolarIconsData(0xe9ed, fontFamily: _fontFamily);
-  static const SolarIconsData volume =
-      SolarIconsData(0xe9ee, fontFamily: _fontFamily);
-  static const SolarIconsData clapperboardPlay =
-      SolarIconsData(0xe9ef, fontFamily: _fontFamily);
-  static const SolarIconsData clapperboard =
-      SolarIconsData(0xe9f0, fontFamily: _fontFamily);
-  static const SolarIconsData gallery =
-      SolarIconsData(0xe9f1, fontFamily: _fontFamily);
-  static const SolarIconsData library =
-      SolarIconsData(0xe9f2, fontFamily: _fontFamily);
-  static const SolarIconsData microphone2 =
-      SolarIconsData(0xe9f3, fontFamily: _fontFamily);
-  static const SolarIconsData musicNote4 =
-      SolarIconsData(0xe9f4, fontFamily: _fontFamily);
-  static const SolarIconsData recordCircle =
-      SolarIconsData(0xe9f5, fontFamily: _fontFamily);
-  static const SolarIconsData record =
-      SolarIconsData(0xe9f6, fontFamily: _fontFamily);
-  static const SolarIconsData repeat =
-      SolarIconsData(0xe9f7, fontFamily: _fontFamily);
-  static const SolarIconsData rewind5SecondsBack =
-      SolarIconsData(0xe9f8, fontFamily: _fontFamily);
-  static const SolarIconsData rewind5SecondsForward =
-      SolarIconsData(0xe9f9, fontFamily: _fontFamily);
-  static const SolarIconsData soundwave =
-      SolarIconsData(0xe9fa, fontFamily: _fontFamily);
-  static const SolarIconsData videoFrameCut =
-      SolarIconsData(0xe9fb, fontFamily: _fontFamily);
-  static const SolarIconsData videoFrame =
-      SolarIconsData(0xe9fc, fontFamily: _fontFamily);
-  static const SolarIconsData volumeLoud =
-      SolarIconsData(0xe9fd, fontFamily: _fontFamily);
-  static const SolarIconsData volumeSmall =
-      SolarIconsData(0xe9fe, fontFamily: _fontFamily);
-  static const SolarIconsData billCheck =
-      SolarIconsData(0xe9ff, fontFamily: _fontFamily);
-  static const SolarIconsData billCross =
-      SolarIconsData(0xea00, fontFamily: _fontFamily);
-  static const SolarIconsData billList =
-      SolarIconsData(0xea01, fontFamily: _fontFamily);
-  static const SolarIconsData bill =
-      SolarIconsData(0xea02, fontFamily: _fontFamily);
-  static const SolarIconsData cashOut =
-      SolarIconsData(0xea03, fontFamily: _fontFamily);
-  static const SolarIconsData dollarMinimalistic =
-      SolarIconsData(0xea04, fontFamily: _fontFamily);
-  static const SolarIconsData moneyBag =
-      SolarIconsData(0xea05, fontFamily: _fontFamily);
-  static const SolarIconsData safe2 =
-      SolarIconsData(0xea06, fontFamily: _fontFamily);
-  static const SolarIconsData banknote2 =
-      SolarIconsData(0xea07, fontFamily: _fontFamily);
-  static const SolarIconsData banknote =
-      SolarIconsData(0xea08, fontFamily: _fontFamily);
-  static const SolarIconsData card2 =
-      SolarIconsData(0xea09, fontFamily: _fontFamily);
-  static const SolarIconsData cardReceive =
-      SolarIconsData(0xea0a, fontFamily: _fontFamily);
-  static const SolarIconsData cardSearch =
-      SolarIconsData(0xea0b, fontFamily: _fontFamily);
-  static const SolarIconsData cardSend =
-      SolarIconsData(0xea0c, fontFamily: _fontFamily);
-  static const SolarIconsData cardTransfer =
-      SolarIconsData(0xea0d, fontFamily: _fontFamily);
-  static const SolarIconsData card =
-      SolarIconsData(0xea0e, fontFamily: _fontFamily);
-  static const SolarIconsData cardholder =
-      SolarIconsData(0xea0f, fontFamily: _fontFamily);
-  static const SolarIconsData dollar =
-      SolarIconsData(0xea10, fontFamily: _fontFamily);
-  static const SolarIconsData euro =
-      SolarIconsData(0xea11, fontFamily: _fontFamily);
-  static const SolarIconsData ruble =
-      SolarIconsData(0xea12, fontFamily: _fontFamily);
-  static const SolarIconsData safeCircle =
-      SolarIconsData(0xea13, fontFamily: _fontFamily);
-  static const SolarIconsData safeSquare =
-      SolarIconsData(0xea14, fontFamily: _fontFamily);
-  static const SolarIconsData saleSquare =
-      SolarIconsData(0xea15, fontFamily: _fontFamily);
-  static const SolarIconsData sale =
-      SolarIconsData(0xea16, fontFamily: _fontFamily);
-  static const SolarIconsData tagHorizontal =
-      SolarIconsData(0xea17, fontFamily: _fontFamily);
-  static const SolarIconsData tagPrice =
-      SolarIconsData(0xea18, fontFamily: _fontFamily);
-  static const SolarIconsData tag =
-      SolarIconsData(0xea19, fontFamily: _fontFamily);
-  static const SolarIconsData tickerStar =
-      SolarIconsData(0xea1a, fontFamily: _fontFamily);
-  static const SolarIconsData ticketSale =
-      SolarIconsData(0xea1b, fontFamily: _fontFamily);
-  static const SolarIconsData ticket =
-      SolarIconsData(0xea1c, fontFamily: _fontFamily);
-  static const SolarIconsData verifiedCheck =
-      SolarIconsData(0xea1d, fontFamily: _fontFamily);
-  static const SolarIconsData wadOfMoney =
-      SolarIconsData(0xea1e, fontFamily: _fontFamily);
-  static const SolarIconsData wallet2 =
-      SolarIconsData(0xea1f, fontFamily: _fontFamily);
-  static const SolarIconsData walletMoney =
-      SolarIconsData(0xea20, fontFamily: _fontFamily);
-  static const SolarIconsData wallet =
-      SolarIconsData(0xea21, fontFamily: _fontFamily);
-  static const SolarIconsData cloudStorage =
-      SolarIconsData(0xea22, fontFamily: _fontFamily);
-  static const SolarIconsData devices =
-      SolarIconsData(0xea23, fontFamily: _fontFamily);
-  static const SolarIconsData flashDrive =
-      SolarIconsData(0xea24, fontFamily: _fontFamily);
-  static const SolarIconsData lightbulbBold =
-      SolarIconsData(0xea25, fontFamily: _fontFamily);
-  static const SolarIconsData lightbulbMinimalistic =
-      SolarIconsData(0xea26, fontFamily: _fontFamily);
-  static const SolarIconsData lightbulb =
-      SolarIconsData(0xea27, fontFamily: _fontFamily);
-  static const SolarIconsData lightning =
-      SolarIconsData(0xea28, fontFamily: _fontFamily);
-  static const SolarIconsData socket =
-      SolarIconsData(0xea29, fontFamily: _fontFamily);
-  static const SolarIconsData ssdRound =
-      SolarIconsData(0xea2a, fontFamily: _fontFamily);
-  static const SolarIconsData ssdSquare =
-      SolarIconsData(0xea2b, fontFamily: _fontFamily);
-  static const SolarIconsData weigher =
-      SolarIconsData(0xea2c, fontFamily: _fontFamily);
-  static const SolarIconsData bluetoothCircle =
-      SolarIconsData(0xea2d, fontFamily: _fontFamily);
-  static const SolarIconsData bluetoothSquare =
-      SolarIconsData(0xea2e, fontFamily: _fontFamily);
-  static const SolarIconsData bluetoothWave =
-      SolarIconsData(0xea2f, fontFamily: _fontFamily);
-  static const SolarIconsData bluetooth =
-      SolarIconsData(0xea30, fontFamily: _fontFamily);
-  static const SolarIconsData diskette =
-      SolarIconsData(0xea31, fontFamily: _fontFamily);
-  static const SolarIconsData display =
-      SolarIconsData(0xea32, fontFamily: _fontFamily);
-  static const SolarIconsData gameboy =
-      SolarIconsData(0xea33, fontFamily: _fontFamily);
-  static const SolarIconsData keyboard =
-      SolarIconsData(0xea34, fontFamily: _fontFamily);
-  static const SolarIconsData monitorCamera =
-      SolarIconsData(0xea35, fontFamily: _fontFamily);
-  static const SolarIconsData monitorSmartphone =
-      SolarIconsData(0xea36, fontFamily: _fontFamily);
-  static const SolarIconsData monitor =
-      SolarIconsData(0xea37, fontFamily: _fontFamily);
-  static const SolarIconsData plugCircle =
-      SolarIconsData(0xea38, fontFamily: _fontFamily);
-  static const SolarIconsData printer2 =
-      SolarIconsData(0xea39, fontFamily: _fontFamily);
-  static const SolarIconsData printerMinimalistic =
-      SolarIconsData(0xea3a, fontFamily: _fontFamily);
-  static const SolarIconsData printer =
-      SolarIconsData(0xea3b, fontFamily: _fontFamily);
-  static const SolarIconsData projector =
-      SolarIconsData(0xea3c, fontFamily: _fontFamily);
-  static const SolarIconsData radioMinimalistic =
-      SolarIconsData(0xea3d, fontFamily: _fontFamily);
-  static const SolarIconsData radio =
-      SolarIconsData(0xea3e, fontFamily: _fontFamily);
-  static const SolarIconsData sdCard =
-      SolarIconsData(0xea3f, fontFamily: _fontFamily);
-  static const SolarIconsData simCardMinimalistic =
-      SolarIconsData(0xea40, fontFamily: _fontFamily);
-  static const SolarIconsData simCard =
-      SolarIconsData(0xea41, fontFamily: _fontFamily);
-  static const SolarIconsData simCards =
-      SolarIconsData(0xea42, fontFamily: _fontFamily);
-  static const SolarIconsData smartSpeaker2 =
-      SolarIconsData(0xea43, fontFamily: _fontFamily);
-  static const SolarIconsData smartSpeakerMinimalistic =
-      SolarIconsData(0xea44, fontFamily: _fontFamily);
-  static const SolarIconsData smartSpeaker =
-      SolarIconsData(0xea45, fontFamily: _fontFamily);
-  static const SolarIconsData telescope =
-      SolarIconsData(0xea46, fontFamily: _fontFamily);
-  static const SolarIconsData tv =
-      SolarIconsData(0xea47, fontFamily: _fontFamily);
-  static const SolarIconsData wirelessCharge =
-      SolarIconsData(0xea48, fontFamily: _fontFamily);
-  static const SolarIconsData airbudsCaseCharge =
-      SolarIconsData(0xea49, fontFamily: _fontFamily);
-  static const SolarIconsData airbudsCaseMinimalistic =
-      SolarIconsData(0xea4a, fontFamily: _fontFamily);
-  static const SolarIconsData airbudsCaseOpen =
-      SolarIconsData(0xea4b, fontFamily: _fontFamily);
-  static const SolarIconsData airbudsCase =
-      SolarIconsData(0xea4c, fontFamily: _fontFamily);
-  static const SolarIconsData airbudsCharge =
-      SolarIconsData(0xea4d, fontFamily: _fontFamily);
-  static const SolarIconsData airbudsCheck =
-      SolarIconsData(0xea4e, fontFamily: _fontFamily);
-  static const SolarIconsData airbudsLeft =
-      SolarIconsData(0xea4f, fontFamily: _fontFamily);
-  static const SolarIconsData airbudsRemove =
-      SolarIconsData(0xea50, fontFamily: _fontFamily);
-  static const SolarIconsData airbudsRight =
-      SolarIconsData(0xea51, fontFamily: _fontFamily);
-  static const SolarIconsData airbuds =
-      SolarIconsData(0xea52, fontFamily: _fontFamily);
-  static const SolarIconsData boombox =
-      SolarIconsData(0xea53, fontFamily: _fontFamily);
-  static const SolarIconsData cassette2 =
-      SolarIconsData(0xea54, fontFamily: _fontFamily);
-  static const SolarIconsData cassette =
-      SolarIconsData(0xea55, fontFamily: _fontFamily);
-  static const SolarIconsData cpuBolt =
-      SolarIconsData(0xea56, fontFamily: _fontFamily);
-  static const SolarIconsData cpu =
-      SolarIconsData(0xea57, fontFamily: _fontFamily);
-  static const SolarIconsData laptop2 =
-      SolarIconsData(0xea58, fontFamily: _fontFamily);
-  static const SolarIconsData laptop3 =
-      SolarIconsData(0xea59, fontFamily: _fontFamily);
-  static const SolarIconsData laptopMinimalistic =
-      SolarIconsData(0xea5a, fontFamily: _fontFamily);
-  static const SolarIconsData laptop =
-      SolarIconsData(0xea5b, fontFamily: _fontFamily);
-  static const SolarIconsData mouseCircle =
-      SolarIconsData(0xea5c, fontFamily: _fontFamily);
-  static const SolarIconsData mouseMinimalistic =
-      SolarIconsData(0xea5d, fontFamily: _fontFamily);
-  static const SolarIconsData mouse =
-      SolarIconsData(0xea5e, fontFamily: _fontFamily);
-  static const SolarIconsData serverMinimalistic =
-      SolarIconsData(0xea5f, fontFamily: _fontFamily);
-  static const SolarIconsData serverPath =
-      SolarIconsData(0xea60, fontFamily: _fontFamily);
-  static const SolarIconsData serverSquareCloud =
-      SolarIconsData(0xea61, fontFamily: _fontFamily);
-  static const SolarIconsData serverSquareUpdate =
-      SolarIconsData(0xea62, fontFamily: _fontFamily);
-  static const SolarIconsData turntableMinimalistic =
-      SolarIconsData(0xea63, fontFamily: _fontFamily);
-  static const SolarIconsData turntableMusicNote =
-      SolarIconsData(0xea64, fontFamily: _fontFamily);
-  static const SolarIconsData turntable =
-      SolarIconsData(0xea65, fontFamily: _fontFamily);
-  static const SolarIconsData gamepadCharge =
-      SolarIconsData(0xea66, fontFamily: _fontFamily);
-  static const SolarIconsData gamepadMinimalistic =
-      SolarIconsData(0xea67, fontFamily: _fontFamily);
-  static const SolarIconsData gamepadNoCharge =
-      SolarIconsData(0xea68, fontFamily: _fontFamily);
-  static const SolarIconsData gamepadOld =
-      SolarIconsData(0xea69, fontFamily: _fontFamily);
-  static const SolarIconsData gamepad =
-      SolarIconsData(0xea6a, fontFamily: _fontFamily);
-  static const SolarIconsData headphonesRoundSound =
-      SolarIconsData(0xea6b, fontFamily: _fontFamily);
-  static const SolarIconsData headphonesRound =
-      SolarIconsData(0xea6c, fontFamily: _fontFamily);
-  static const SolarIconsData headphonesSquareSound =
-      SolarIconsData(0xea6d, fontFamily: _fontFamily);
-  static const SolarIconsData headphonesSquare =
-      SolarIconsData(0xea6e, fontFamily: _fontFamily);
-  static const SolarIconsData iPhone =
-      SolarIconsData(0xea6f, fontFamily: _fontFamily);
-  static const SolarIconsData server2 =
-      SolarIconsData(0xea70, fontFamily: _fontFamily);
-  static const SolarIconsData serverSquare =
-      SolarIconsData(0xea71, fontFamily: _fontFamily);
-  static const SolarIconsData server =
-      SolarIconsData(0xea72, fontFamily: _fontFamily);
-  static const SolarIconsData smartphone2 =
-      SolarIconsData(0xea73, fontFamily: _fontFamily);
-  static const SolarIconsData smartphoneRotate2 =
-      SolarIconsData(0xea74, fontFamily: _fontFamily);
-  static const SolarIconsData smartphoneRotateAngle =
-      SolarIconsData(0xea75, fontFamily: _fontFamily);
-  static const SolarIconsData smartphoneRotateOrientation =
-      SolarIconsData(0xea76, fontFamily: _fontFamily);
-  static const SolarIconsData smartphoneUpdate =
-      SolarIconsData(0xea77, fontFamily: _fontFamily);
-  static const SolarIconsData smartphoneVibration =
-      SolarIconsData(0xea78, fontFamily: _fontFamily);
-  static const SolarIconsData smartphone =
-      SolarIconsData(0xea79, fontFamily: _fontFamily);
-  static const SolarIconsData tablet =
-      SolarIconsData(0xea7a, fontFamily: _fontFamily);
-  static const SolarIconsData cloudDownload =
-      SolarIconsData(0xea7b, fontFamily: _fontFamily);
-  static const SolarIconsData cloudUpload =
-      SolarIconsData(0xea7c, fontFamily: _fontFamily);
-  static const SolarIconsData cloudyMoon =
-      SolarIconsData(0xea7d, fontFamily: _fontFamily);
-  static const SolarIconsData moonFog =
-      SolarIconsData(0xea7e, fontFamily: _fontFamily);
-  static const SolarIconsData moonSleep =
-      SolarIconsData(0xea7f, fontFamily: _fontFamily);
-  static const SolarIconsData moonStars =
-      SolarIconsData(0xea80, fontFamily: _fontFamily);
-  static const SolarIconsData moon =
-      SolarIconsData(0xea81, fontFamily: _fontFamily);
-  static const SolarIconsData snowflake =
-      SolarIconsData(0xea82, fontFamily: _fontFamily);
-  static const SolarIconsData stars =
-      SolarIconsData(0xea83, fontFamily: _fontFamily);
-  static const SolarIconsData sun2 =
-      SolarIconsData(0xea84, fontFamily: _fontFamily);
-  static const SolarIconsData sunfog =
-      SolarIconsData(0xea85, fontFamily: _fontFamily);
-  static const SolarIconsData sun =
-      SolarIconsData(0xea86, fontFamily: _fontFamily);
-  static const SolarIconsData sunrise =
-      SolarIconsData(0xea87, fontFamily: _fontFamily);
-  static const SolarIconsData sunset =
-      SolarIconsData(0xea88, fontFamily: _fontFamily);
-  static const SolarIconsData temperature =
-      SolarIconsData(0xea89, fontFamily: _fontFamily);
-  static const SolarIconsData tornadoSmall =
-      SolarIconsData(0xea8a, fontFamily: _fontFamily);
-  static const SolarIconsData waterdrops =
-      SolarIconsData(0xea8b, fontFamily: _fontFamily);
-  static const SolarIconsData wind =
-      SolarIconsData(0xea8c, fontFamily: _fontFamily);
-  static const SolarIconsData cloudBoltMinimalistic =
-      SolarIconsData(0xea8d, fontFamily: _fontFamily);
-  static const SolarIconsData cloudBolt =
-      SolarIconsData(0xea8e, fontFamily: _fontFamily);
-  static const SolarIconsData cloudCheck =
-      SolarIconsData(0xea8f, fontFamily: _fontFamily);
-  static const SolarIconsData cloudMinus =
-      SolarIconsData(0xea90, fontFamily: _fontFamily);
-  static const SolarIconsData cloudPlus =
-      SolarIconsData(0xea91, fontFamily: _fontFamily);
-  static const SolarIconsData cloudRain =
-      SolarIconsData(0xea92, fontFamily: _fontFamily);
-  static const SolarIconsData cloudSnowfallMinimalistic =
-      SolarIconsData(0xea93, fontFamily: _fontFamily);
-  static const SolarIconsData cloudSnowfall =
-      SolarIconsData(0xea94, fontFamily: _fontFamily);
-  static const SolarIconsData cloudStorm =
-      SolarIconsData(0xea95, fontFamily: _fontFamily);
-  static const SolarIconsData cloudSun2 =
-      SolarIconsData(0xea96, fontFamily: _fontFamily);
-  static const SolarIconsData cloudSun =
-      SolarIconsData(0xea97, fontFamily: _fontFamily);
-  static const SolarIconsData cloudWaterdrop =
-      SolarIconsData(0xea98, fontFamily: _fontFamily);
-  static const SolarIconsData cloudWaterdrops =
-      SolarIconsData(0xea99, fontFamily: _fontFamily);
-  static const SolarIconsData cloud =
-      SolarIconsData(0xea9a, fontFamily: _fontFamily);
-  static const SolarIconsData clouds =
-      SolarIconsData(0xea9b, fontFamily: _fontFamily);
-  static const SolarIconsData cloudCross =
-      SolarIconsData(0xea9c, fontFamily: _fontFamily);
-  static const SolarIconsData fog =
-      SolarIconsData(0xea9d, fontFamily: _fontFamily);
-  static const SolarIconsData tornado =
-      SolarIconsData(0xea9e, fontFamily: _fontFamily);
-  static const SolarIconsData fileCorrupted =
-      SolarIconsData(0xea9f, fontFamily: _fontFamily);
-  static const SolarIconsData fileSmile =
-      SolarIconsData(0xeaa0, fontFamily: _fontFamily);
-  static const SolarIconsData zipFile =
-      SolarIconsData(0xeaa1, fontFamily: _fontFamily);
-  static const SolarIconsData codeFile =
-      SolarIconsData(0xeaa2, fontFamily: _fontFamily);
-  static const SolarIconsData figmaFile =
-      SolarIconsData(0xeaa3, fontFamily: _fontFamily);
-  static const SolarIconsData fileCheck =
-      SolarIconsData(0xeaa4, fontFamily: _fontFamily);
-  static const SolarIconsData fileDownload =
-      SolarIconsData(0xeaa5, fontFamily: _fontFamily);
-  static const SolarIconsData fileFavourite =
-      SolarIconsData(0xeaa6, fontFamily: _fontFamily);
-  static const SolarIconsData fileLeft =
-      SolarIconsData(0xeaa7, fontFamily: _fontFamily);
-  static const SolarIconsData fileRemove =
-      SolarIconsData(0xeaa8, fontFamily: _fontFamily);
-  static const SolarIconsData fileRight =
-      SolarIconsData(0xeaa9, fontFamily: _fontFamily);
-  static const SolarIconsData fileSend =
-      SolarIconsData(0xeaaa, fontFamily: _fontFamily);
-  static const SolarIconsData fileText =
-      SolarIconsData(0xeaab, fontFamily: _fontFamily);
-  static const SolarIconsData file =
-      SolarIconsData(0xeaac, fontFamily: _fontFamily);
-  static const SolarIconsData cloudFile =
-      SolarIconsData(0xeaad, fontFamily: _fontFamily);
-  static const SolarIconsData folder2 =
-      SolarIconsData(0xeaae, fontFamily: _fontFamily);
-  static const SolarIconsData folderCheck =
-      SolarIconsData(0xeaaf, fontFamily: _fontFamily);
-  static const SolarIconsData folderCloud =
-      SolarIconsData(0xeab0, fontFamily: _fontFamily);
-  static const SolarIconsData folderError =
-      SolarIconsData(0xeab1, fontFamily: _fontFamily);
-  static const SolarIconsData folderFavouriteBookmark =
-      SolarIconsData(0xeab2, fontFamily: _fontFamily);
-  static const SolarIconsData folderFavouriteStar =
-      SolarIconsData(0xeab3, fontFamily: _fontFamily);
-  static const SolarIconsData folderOpen =
-      SolarIconsData(0xeab4, fontFamily: _fontFamily);
-  static const SolarIconsData folderPathConnect =
-      SolarIconsData(0xeab5, fontFamily: _fontFamily);
-  static const SolarIconsData folderSecurity =
-      SolarIconsData(0xeab6, fontFamily: _fontFamily);
-  static const SolarIconsData folderWithFiles =
-      SolarIconsData(0xeab7, fontFamily: _fontFamily);
-  static const SolarIconsData folder =
-      SolarIconsData(0xeab8, fontFamily: _fontFamily);
-  static const SolarIconsData moveToFolder =
-      SolarIconsData(0xeab9, fontFamily: _fontFamily);
-  static const SolarIconsData removeFolder =
-      SolarIconsData(0xeaba, fontFamily: _fontFamily);
-  static const SolarIconsData addFolder =
-      SolarIconsData(0xeabb, fontFamily: _fontFamily);
-  static const SolarIconsData starFall2 =
-      SolarIconsData(0xeabc, fontFamily: _fontFamily);
-  static const SolarIconsData starFallMinimalistic2 =
-      SolarIconsData(0xeabd, fontFamily: _fontFamily);
-  static const SolarIconsData starFallMinimalistic =
-      SolarIconsData(0xeabe, fontFamily: _fontFamily);
-  static const SolarIconsData starRing =
-      SolarIconsData(0xeabf, fontFamily: _fontFamily);
-  static const SolarIconsData starRings =
-      SolarIconsData(0xeac0, fontFamily: _fontFamily);
-  static const SolarIconsData star =
-      SolarIconsData(0xeac1, fontFamily: _fontFamily);
-  static const SolarIconsData starsLine =
-      SolarIconsData(0xeac2, fontFamily: _fontFamily);
-  static const SolarIconsData starsMinimalistic =
-      SolarIconsData(0xeac3, fontFamily: _fontFamily);
-  static const SolarIconsData stars1 =
-      SolarIconsData(0xeac4, fontFamily: _fontFamily);
-  static const SolarIconsData asteroid =
-      SolarIconsData(0xeac5, fontFamily: _fontFamily);
-  static const SolarIconsData atom =
-      SolarIconsData(0xeac6, fontFamily: _fontFamily);
-  static const SolarIconsData blackHole2 =
-      SolarIconsData(0xeac7, fontFamily: _fontFamily);
-  static const SolarIconsData blackHole3 =
-      SolarIconsData(0xeac8, fontFamily: _fontFamily);
-  static const SolarIconsData blackHole =
-      SolarIconsData(0xeac9, fontFamily: _fontFamily);
-  static const SolarIconsData earth =
-      SolarIconsData(0xeaca, fontFamily: _fontFamily);
-  static const SolarIconsData infinity =
-      SolarIconsData(0xeacb, fontFamily: _fontFamily);
-  static const SolarIconsData men =
-      SolarIconsData(0xeacc, fontFamily: _fontFamily);
-  static const SolarIconsData planet2 =
-      SolarIconsData(0xeacd, fontFamily: _fontFamily);
-  static const SolarIconsData planet3 =
-      SolarIconsData(0xeace, fontFamily: _fontFamily);
-  static const SolarIconsData planet4 =
-      SolarIconsData(0xeacf, fontFamily: _fontFamily);
-  static const SolarIconsData planet =
-      SolarIconsData(0xead0, fontFamily: _fontFamily);
-  static const SolarIconsData rocket2 =
-      SolarIconsData(0xead1, fontFamily: _fontFamily);
-  static const SolarIconsData rocket =
-      SolarIconsData(0xead2, fontFamily: _fontFamily);
-  static const SolarIconsData satellite =
-      SolarIconsData(0xead3, fontFamily: _fontFamily);
-  static const SolarIconsData starAngle =
-      SolarIconsData(0xead4, fontFamily: _fontFamily);
-  static const SolarIconsData starCircle =
-      SolarIconsData(0xead5, fontFamily: _fontFamily);
-  static const SolarIconsData starFall =
-      SolarIconsData(0xead6, fontFamily: _fontFamily);
-  static const SolarIconsData starRainbow =
-      SolarIconsData(0xead7, fontFamily: _fontFamily);
-  static const SolarIconsData ufo2 =
-      SolarIconsData(0xead8, fontFamily: _fontFamily);
-  static const SolarIconsData ufo3 =
-      SolarIconsData(0xead9, fontFamily: _fontFamily);
-  static const SolarIconsData ufo =
-      SolarIconsData(0xeada, fontFamily: _fontFamily);
-  static const SolarIconsData women =
-      SolarIconsData(0xeadb, fontFamily: _fontFamily);
-  static const SolarIconsData confoundedCircle =
-      SolarIconsData(0xeadc, fontFamily: _fontFamily);
-  static const SolarIconsData confoundedSquare =
-      SolarIconsData(0xeadd, fontFamily: _fontFamily);
-  static const SolarIconsData emojiFunnyCircle =
-      SolarIconsData(0xeade, fontFamily: _fontFamily);
-  static const SolarIconsData emojiFunnySquare =
-      SolarIconsData(0xeadf, fontFamily: _fontFamily);
-  static const SolarIconsData faceScanCircle =
-      SolarIconsData(0xeae0, fontFamily: _fontFamily);
-  static const SolarIconsData faceScanSquare =
-      SolarIconsData(0xeae1, fontFamily: _fontFamily);
-  static const SolarIconsData facemaskCircle =
-      SolarIconsData(0xeae2, fontFamily: _fontFamily);
-  static const SolarIconsData facemaskSquare =
-      SolarIconsData(0xeae3, fontFamily: _fontFamily);
-  static const SolarIconsData sadCircle =
-      SolarIconsData(0xeae4, fontFamily: _fontFamily);
-  static const SolarIconsData sadSquare =
-      SolarIconsData(0xeae5, fontFamily: _fontFamily);
-  static const SolarIconsData sleepingCircle =
-      SolarIconsData(0xeae6, fontFamily: _fontFamily);
-  static const SolarIconsData sleepingSquare =
-      SolarIconsData(0xeae7, fontFamily: _fontFamily);
-  static const SolarIconsData stickerCircle =
-      SolarIconsData(0xeae8, fontFamily: _fontFamily);
-  static const SolarIconsData stickerSmileCircle2 =
-      SolarIconsData(0xeae9, fontFamily: _fontFamily);
-  static const SolarIconsData stickerSmileCircle =
-      SolarIconsData(0xeaea, fontFamily: _fontFamily);
-  static const SolarIconsData stickerSmileSquare =
-      SolarIconsData(0xeaeb, fontFamily: _fontFamily);
-  static const SolarIconsData stickerSquare =
-      SolarIconsData(0xeaec, fontFamily: _fontFamily);
-  static const SolarIconsData expressionlessCircle =
-      SolarIconsData(0xeaed, fontFamily: _fontFamily);
-  static const SolarIconsData expressionlessSquare =
-      SolarIconsData(0xeaee, fontFamily: _fontFamily);
-  static const SolarIconsData smileCircle =
-      SolarIconsData(0xeaef, fontFamily: _fontFamily);
-  static const SolarIconsData smileSquare =
-      SolarIconsData(0xeaf0, fontFamily: _fontFamily);
-  static const SolarIconsData balls =
-      SolarIconsData(0xeaf1, fontFamily: _fontFamily);
-  static const SolarIconsData basketball =
-      SolarIconsData(0xeaf2, fontFamily: _fontFamily);
-  static const SolarIconsData bodyShapeMinimalistic =
-      SolarIconsData(0xeaf3, fontFamily: _fontFamily);
-  static const SolarIconsData bodyShape =
-      SolarIconsData(0xeaf4, fontFamily: _fontFamily);
-  static const SolarIconsData bowling =
-      SolarIconsData(0xeaf5, fontFamily: _fontFamily);
-  static const SolarIconsData dumbbellLargeMinimalistic =
-      SolarIconsData(0xeaf6, fontFamily: _fontFamily);
-  static const SolarIconsData dumbbellLarge =
-      SolarIconsData(0xeaf7, fontFamily: _fontFamily);
-  static const SolarIconsData dumbbellSmall =
-      SolarIconsData(0xeaf8, fontFamily: _fontFamily);
-  static const SolarIconsData dumbbell =
-      SolarIconsData(0xeaf9, fontFamily: _fontFamily);
-  static const SolarIconsData dumbbells2 =
-      SolarIconsData(0xeafa, fontFamily: _fontFamily);
-  static const SolarIconsData dumbbells =
-      SolarIconsData(0xeafb, fontFamily: _fontFamily);
-  static const SolarIconsData football =
-      SolarIconsData(0xeafc, fontFamily: _fontFamily);
-  static const SolarIconsData golf =
-      SolarIconsData(0xeafd, fontFamily: _fontFamily);
-  static const SolarIconsData meditationRound =
-      SolarIconsData(0xeafe, fontFamily: _fontFamily);
-  static const SolarIconsData meditation =
-      SolarIconsData(0xeaff, fontFamily: _fontFamily);
-  static const SolarIconsData ranking =
-      SolarIconsData(0xeb00, fontFamily: _fontFamily);
-  static const SolarIconsData rugby =
-      SolarIconsData(0xeb01, fontFamily: _fontFamily);
-  static const SolarIconsData runningRound =
-      SolarIconsData(0xeb02, fontFamily: _fontFamily);
-  static const SolarIconsData stretchingRound =
-      SolarIconsData(0xeb03, fontFamily: _fontFamily);
-  static const SolarIconsData stretching =
-      SolarIconsData(0xeb04, fontFamily: _fontFamily);
-  static const SolarIconsData swimming =
-      SolarIconsData(0xeb05, fontFamily: _fontFamily);
-  static const SolarIconsData tennis2 =
-      SolarIconsData(0xeb06, fontFamily: _fontFamily);
-  static const SolarIconsData tennis =
-      SolarIconsData(0xeb07, fontFamily: _fontFamily);
-  static const SolarIconsData treadmillRound =
-      SolarIconsData(0xeb08, fontFamily: _fontFamily);
-  static const SolarIconsData treadmill =
-      SolarIconsData(0xeb09, fontFamily: _fontFamily);
-  static const SolarIconsData volleyball2 =
-      SolarIconsData(0xeb0a, fontFamily: _fontFamily);
-  static const SolarIconsData volleyball =
-      SolarIconsData(0xeb0b, fontFamily: _fontFamily);
-  static const SolarIconsData waterSun =
-      SolarIconsData(0xeb0c, fontFamily: _fontFamily);
-  static const SolarIconsData water =
-      SolarIconsData(0xeb0d, fontFamily: _fontFamily);
-  static const SolarIconsData bicyclingRound =
-      SolarIconsData(0xeb0e, fontFamily: _fontFamily);
-  static const SolarIconsData bicycling =
-      SolarIconsData(0xeb0f, fontFamily: _fontFamily);
-  static const SolarIconsData hikingMinimalistic =
-      SolarIconsData(0xeb10, fontFamily: _fontFamily);
-  static const SolarIconsData hikingRound =
-      SolarIconsData(0xeb11, fontFamily: _fontFamily);
-  static const SolarIconsData hiking =
-      SolarIconsData(0xeb12, fontFamily: _fontFamily);
-  static const SolarIconsData running_2 =
-      SolarIconsData(0xeb13, fontFamily: _fontFamily);
-  static const SolarIconsData running =
-      SolarIconsData(0xeb14, fontFamily: _fontFamily);
-  static const SolarIconsData skateboard =
-      SolarIconsData(0xeb15, fontFamily: _fontFamily);
-  static const SolarIconsData skateboardingRound =
-      SolarIconsData(0xeb16, fontFamily: _fontFamily);
-  static const SolarIconsData skateboarding =
-      SolarIconsData(0xeb17, fontFamily: _fontFamily);
-  static const SolarIconsData walkingRound =
-      SolarIconsData(0xeb18, fontFamily: _fontFamily);
-  static const SolarIconsData walking =
-      SolarIconsData(0xeb19, fontFamily: _fontFamily);
-  static const SolarIconsData magnifierBug =
-      SolarIconsData(0xeb1a, fontFamily: _fontFamily);
-  static const SolarIconsData magnifierZoomIn =
-      SolarIconsData(0xeb1b, fontFamily: _fontFamily);
-  static const SolarIconsData magnifierZoomOut =
-      SolarIconsData(0xeb1c, fontFamily: _fontFamily);
-  static const SolarIconsData magnifier =
-      SolarIconsData(0xeb1d, fontFamily: _fontFamily);
-  static const SolarIconsData minimalisticMagnifierBug =
-      SolarIconsData(0xeb1e, fontFamily: _fontFamily);
-  static const SolarIconsData minimalisticMagnifierZoomIn =
-      SolarIconsData(0xeb1f, fontFamily: _fontFamily);
-  static const SolarIconsData minimalisticMagnifierZoomOut =
-      SolarIconsData(0xeb20, fontFamily: _fontFamily);
-  static const SolarIconsData minimalisticMagnifier =
-      SolarIconsData(0xeb21, fontFamily: _fontFamily);
-  static const SolarIconsData roundedMagnifierBug =
-      SolarIconsData(0xeb22, fontFamily: _fontFamily);
-  static const SolarIconsData roundedMagnifierZoomIn =
-      SolarIconsData(0xeb23, fontFamily: _fontFamily);
-  static const SolarIconsData roundedMagnifierZoomOut =
-      SolarIconsData(0xeb24, fontFamily: _fontFamily);
-  static const SolarIconsData roundedMagnifier =
-      SolarIconsData(0xeb25, fontFamily: _fontFamily);
-  static const SolarIconsData calendarAdd =
-      SolarIconsData(0xeb26, fontFamily: _fontFamily);
-  static const SolarIconsData calendarDate =
-      SolarIconsData(0xeb27, fontFamily: _fontFamily);
-  static const SolarIconsData calendarMark =
-      SolarIconsData(0xeb28, fontFamily: _fontFamily);
-  static const SolarIconsData calendarMinimalistic =
-      SolarIconsData(0xeb29, fontFamily: _fontFamily);
-  static const SolarIconsData calendarSearch =
-      SolarIconsData(0xeb2a, fontFamily: _fontFamily);
-  static const SolarIconsData calendar =
-      SolarIconsData(0xeb2b, fontFamily: _fontFamily);
-  static const SolarIconsData hourglassLine =
-      SolarIconsData(0xeb2c, fontFamily: _fontFamily);
-  static const SolarIconsData watchRound =
-      SolarIconsData(0xeb2d, fontFamily: _fontFamily);
-  static const SolarIconsData watchSquareMinimalisticCharge =
-      SolarIconsData(0xeb2e, fontFamily: _fontFamily);
-  static const SolarIconsData watchSquareMinimalistic =
-      SolarIconsData(0xeb2f, fontFamily: _fontFamily);
-  static const SolarIconsData watchSquare =
-      SolarIconsData(0xeb30, fontFamily: _fontFamily);
-  static const SolarIconsData alarmAdd =
-      SolarIconsData(0xeb31, fontFamily: _fontFamily);
-  static const SolarIconsData alarmPause =
-      SolarIconsData(0xeb32, fontFamily: _fontFamily);
-  static const SolarIconsData alarmPlay =
-      SolarIconsData(0xeb33, fontFamily: _fontFamily);
-  static const SolarIconsData alarmRemove =
-      SolarIconsData(0xeb34, fontFamily: _fontFamily);
-  static const SolarIconsData alarmSleep =
-      SolarIconsData(0xeb35, fontFamily: _fontFamily);
-  static const SolarIconsData alarmTurnOff =
-      SolarIconsData(0xeb36, fontFamily: _fontFamily);
-  static const SolarIconsData alarm =
-      SolarIconsData(0xeb37, fontFamily: _fontFamily);
-  static const SolarIconsData clockCircle =
-      SolarIconsData(0xeb38, fontFamily: _fontFamily);
-  static const SolarIconsData clockSquare =
-      SolarIconsData(0xeb39, fontFamily: _fontFamily);
-  static const SolarIconsData history_2 =
-      SolarIconsData(0xeb3a, fontFamily: _fontFamily);
-  static const SolarIconsData history3 =
-      SolarIconsData(0xeb3b, fontFamily: _fontFamily);
-  static const SolarIconsData history =
-      SolarIconsData(0xeb3c, fontFamily: _fontFamily);
-  static const SolarIconsData hourglass =
-      SolarIconsData(0xeb3d, fontFamily: _fontFamily);
-  static const SolarIconsData stopwatchPause =
-      SolarIconsData(0xeb3e, fontFamily: _fontFamily);
-  static const SolarIconsData stopwatchPlay =
-      SolarIconsData(0xeb3f, fontFamily: _fontFamily);
-  static const SolarIconsData stopwatch =
-      SolarIconsData(0xeb40, fontFamily: _fontFamily);
-  static const SolarIconsData sortFromTopToBottom =
-      SolarIconsData(0xeb41, fontFamily: _fontFamily);
-  static const SolarIconsData sortFromBottomToTop =
-      SolarIconsData(0xeb42, fontFamily: _fontFamily);
-  static const SolarIconsData sortByTime =
-      SolarIconsData(0xeb43, fontFamily: _fontFamily);
-  static const SolarIconsData sortByAlphabet =
-      SolarIconsData(0xeb44, fontFamily: _fontFamily);
-  static const SolarIconsData playlist =
-      SolarIconsData(0xeb45, fontFamily: _fontFamily);
-  static const SolarIconsData playlistMinimalistic3 =
-      SolarIconsData(0xeb46, fontFamily: _fontFamily);
-  static const SolarIconsData playlistMinimalistic2 =
-      SolarIconsData(0xeb47, fontFamily: _fontFamily);
-  static const SolarIconsData playlist_2 =
-      SolarIconsData(0xeb48, fontFamily: _fontFamily);
-  static const SolarIconsData playlistMinimalistic =
-      SolarIconsData(0xeb49, fontFamily: _fontFamily);
-  static const SolarIconsData list_1 =
-      SolarIconsData(0xeb4a, fontFamily: _fontFamily);
-  static const SolarIconsData list =
-      SolarIconsData(0xeb4b, fontFamily: _fontFamily);
-  static const SolarIconsData listUp =
-      SolarIconsData(0xeb4c, fontFamily: _fontFamily);
-  static const SolarIconsData listUpMinimalistic =
-      SolarIconsData(0xeb4d, fontFamily: _fontFamily);
-  static const SolarIconsData listHeart =
-      SolarIconsData(0xeb4e, fontFamily: _fontFamily);
-  static const SolarIconsData listHeartMinimalistic =
-      SolarIconsData(0xeb4f, fontFamily: _fontFamily);
-  static const SolarIconsData listDown =
-      SolarIconsData(0xeb50, fontFamily: _fontFamily);
-  static const SolarIconsData listDownMinimalistic =
-      SolarIconsData(0xeb51, fontFamily: _fontFamily);
-  static const SolarIconsData listCross =
-      SolarIconsData(0xeb52, fontFamily: _fontFamily);
-  static const SolarIconsData listCrossMinimalistic =
-      SolarIconsData(0xeb53, fontFamily: _fontFamily);
-  static const SolarIconsData listCheck =
-      SolarIconsData(0xeb54, fontFamily: _fontFamily);
-  static const SolarIconsData listCheckMinimalistic =
-      SolarIconsData(0xeb55, fontFamily: _fontFamily);
-  static const SolarIconsData listArrowUp =
-      SolarIconsData(0xeb56, fontFamily: _fontFamily);
-  static const SolarIconsData listArrowUpMinimalistic =
-      SolarIconsData(0xeb57, fontFamily: _fontFamily);
-  static const SolarIconsData listArrowDown =
-      SolarIconsData(0xeb58, fontFamily: _fontFamily);
-  static const SolarIconsData listArrowDownMinimalistic =
-      SolarIconsData(0xeb59, fontFamily: _fontFamily);
-  static const SolarIconsData checklist =
-      SolarIconsData(0xeb5a, fontFamily: _fontFamily);
-  static const SolarIconsData checklistMinimalistic =
-      SolarIconsData(0xeb5b, fontFamily: _fontFamily);
-  static const SolarIconsData bill1 =
-      SolarIconsData(0xeb5c, fontFamily: _fontFamily);
-  static const SolarIconsData callMedicine =
-      SolarIconsData(0xeb5d, fontFamily: _fontFamily);
-  static const SolarIconsData recordCircle1 =
-      SolarIconsData(0xeb5e, fontFamily: _fontFamily);
-  static const SolarIconsData recordMinimalistic =
-      SolarIconsData(0xeb5f, fontFamily: _fontFamily);
-  static const SolarIconsData recordSquare =
-      SolarIconsData(0xeb60, fontFamily: _fontFamily);
-  static const SolarIconsData callCancelRounded =
-      SolarIconsData(0xeb61, fontFamily: _fontFamily);
-  static const SolarIconsData callCancel =
-      SolarIconsData(0xeb62, fontFamily: _fontFamily);
-  static const SolarIconsData callChatRounded =
-      SolarIconsData(0xeb63, fontFamily: _fontFamily);
-  static const SolarIconsData callChat =
-      SolarIconsData(0xeb64, fontFamily: _fontFamily);
-  static const SolarIconsData callDroppedRounded =
-      SolarIconsData(0xeb65, fontFamily: _fontFamily);
-  static const SolarIconsData callDropped =
-      SolarIconsData(0xeb66, fontFamily: _fontFamily);
-  static const SolarIconsData callMedicineRounded =
-      SolarIconsData(0xeb67, fontFamily: _fontFamily);
-  static const SolarIconsData endCallRounded =
-      SolarIconsData(0xeb68, fontFamily: _fontFamily);
-  static const SolarIconsData endCall =
-      SolarIconsData(0xeb69, fontFamily: _fontFamily);
-  static const SolarIconsData incomingCallRounded =
-      SolarIconsData(0xeb6a, fontFamily: _fontFamily);
-  static const SolarIconsData incomingCall =
-      SolarIconsData(0xeb6b, fontFamily: _fontFamily);
-  static const SolarIconsData outgoingCallRounded =
-      SolarIconsData(0xeb6c, fontFamily: _fontFamily);
-  static const SolarIconsData outgoingCall =
-      SolarIconsData(0xeb6d, fontFamily: _fontFamily);
-  static const SolarIconsData phoneCallingRounded =
-      SolarIconsData(0xeb6e, fontFamily: _fontFamily);
-  static const SolarIconsData phoneCalling =
-      SolarIconsData(0xeb6f, fontFamily: _fontFamily);
-  static const SolarIconsData phoneRounded =
-      SolarIconsData(0xeb70, fontFamily: _fontFamily);
-  static const SolarIconsData phone =
-      SolarIconsData(0xeb71, fontFamily: _fontFamily);
-  static const SolarIconsData health =
-      SolarIconsData(0xeb72, fontFamily: _fontFamily);
-  static const SolarIconsData heartPulse2 =
-      SolarIconsData(0xeb73, fontFamily: _fontFamily);
-  static const SolarIconsData heartPulse =
-      SolarIconsData(0xeb74, fontFamily: _fontFamily);
-  static const SolarIconsData medicalKit =
-      SolarIconsData(0xeb75, fontFamily: _fontFamily);
-  static const SolarIconsData pulse_2 =
-      SolarIconsData(0xeb76, fontFamily: _fontFamily);
-  static const SolarIconsData pulse =
-      SolarIconsData(0xeb77, fontFamily: _fontFamily);
-  static const SolarIconsData testTubeMinimalistic =
-      SolarIconsData(0xeb78, fontFamily: _fontFamily);
-  static const SolarIconsData testTube =
-      SolarIconsData(0xeb79, fontFamily: _fontFamily);
-  static const SolarIconsData virus =
-      SolarIconsData(0xeb7a, fontFamily: _fontFamily);
-  static const SolarIconsData adhesivePlaster2 =
-      SolarIconsData(0xeb7b, fontFamily: _fontFamily);
-  static const SolarIconsData adhesivePlaster =
-      SolarIconsData(0xeb7c, fontFamily: _fontFamily);
-  static const SolarIconsData bacteria =
-      SolarIconsData(0xeb7d, fontFamily: _fontFamily);
-  static const SolarIconsData benzeneRing =
-      SolarIconsData(0xeb7e, fontFamily: _fontFamily);
-  static const SolarIconsData boneBroken =
-      SolarIconsData(0xeb7f, fontFamily: _fontFamily);
-  static const SolarIconsData boneCrack =
-      SolarIconsData(0xeb80, fontFamily: _fontFamily);
-  static const SolarIconsData bone =
-      SolarIconsData(0xeb81, fontFamily: _fontFamily);
-  static const SolarIconsData bones =
-      SolarIconsData(0xeb82, fontFamily: _fontFamily);
-  static const SolarIconsData dna =
-      SolarIconsData(0xeb83, fontFamily: _fontFamily);
-  static const SolarIconsData dropper_2 =
-      SolarIconsData(0xeb84, fontFamily: _fontFamily);
-  static const SolarIconsData dropper_3 =
-      SolarIconsData(0xeb85, fontFamily: _fontFamily);
-  static const SolarIconsData dropperMinimalistic2 =
-      SolarIconsData(0xeb86, fontFamily: _fontFamily);
-  static const SolarIconsData dropperMinimalistic =
-      SolarIconsData(0xeb87, fontFamily: _fontFamily);
-  static const SolarIconsData dropper =
-      SolarIconsData(0xeb88, fontFamily: _fontFamily);
-  static const SolarIconsData jarOfPills2 =
-      SolarIconsData(0xeb89, fontFamily: _fontFamily);
-  static const SolarIconsData jarOfPills =
-      SolarIconsData(0xeb8a, fontFamily: _fontFamily);
-  static const SolarIconsData pill =
-      SolarIconsData(0xeb8b, fontFamily: _fontFamily);
-  static const SolarIconsData pills_2 =
-      SolarIconsData(0xeb8c, fontFamily: _fontFamily);
-  static const SolarIconsData pills_3 =
-      SolarIconsData(0xeb8d, fontFamily: _fontFamily);
-  static const SolarIconsData pills =
-      SolarIconsData(0xeb8e, fontFamily: _fontFamily);
-  static const SolarIconsData stethoscope =
-      SolarIconsData(0xeb8f, fontFamily: _fontFamily);
-  static const SolarIconsData syringe =
-      SolarIconsData(0xeb90, fontFamily: _fontFamily);
-  static const SolarIconsData thermometer =
-      SolarIconsData(0xeb91, fontFamily: _fontFamily);
-  static const SolarIconsData armchair_2 =
-      SolarIconsData(0xeb92, fontFamily: _fontFamily);
-  static const SolarIconsData armchair =
-      SolarIconsData(0xeb93, fontFamily: _fontFamily);
-  static const SolarIconsData barChair =
-      SolarIconsData(0xeb94, fontFamily: _fontFamily);
-  static const SolarIconsData bed =
-      SolarIconsData(0xeb95, fontFamily: _fontFamily);
-  static const SolarIconsData bedsideTable2 =
-      SolarIconsData(0xeb96, fontFamily: _fontFamily);
-  static const SolarIconsData bedsideTable3 =
-      SolarIconsData(0xeb97, fontFamily: _fontFamily);
-  static const SolarIconsData bedsideTable =
-      SolarIconsData(0xeb98, fontFamily: _fontFamily);
-  static const SolarIconsData chair_2 =
-      SolarIconsData(0xeb99, fontFamily: _fontFamily);
-  static const SolarIconsData chair =
-      SolarIconsData(0xeb9a, fontFamily: _fontFamily);
-  static const SolarIconsData closet_2 =
-      SolarIconsData(0xeb9b, fontFamily: _fontFamily);
-  static const SolarIconsData floorLampMinimalistic =
-      SolarIconsData(0xeb9c, fontFamily: _fontFamily);
-  static const SolarIconsData floorLamp =
-      SolarIconsData(0xeb9d, fontFamily: _fontFamily);
-  static const SolarIconsData fridge =
-      SolarIconsData(0xeb9e, fontFamily: _fontFamily);
-  static const SolarIconsData lamp =
-      SolarIconsData(0xeb9f, fontFamily: _fontFamily);
-  static const SolarIconsData smartVacuumCleaner_2 =
-      SolarIconsData(0xeba0, fontFamily: _fontFamily);
-  static const SolarIconsData smartVacuumCleaner =
-      SolarIconsData(0xeba1, fontFamily: _fontFamily);
-  static const SolarIconsData volumeKnob =
-      SolarIconsData(0xeba2, fontFamily: _fontFamily);
-  static const SolarIconsData bath =
-      SolarIconsData(0xeba3, fontFamily: _fontFamily);
-  static const SolarIconsData bedsideTable4 =
-      SolarIconsData(0xeba4, fontFamily: _fontFamily);
-  static const SolarIconsData chandelier =
-      SolarIconsData(0xeba5, fontFamily: _fontFamily);
-  static const SolarIconsData closet =
-      SolarIconsData(0xeba6, fontFamily: _fontFamily);
-  static const SolarIconsData conditioner_2 =
-      SolarIconsData(0xeba7, fontFamily: _fontFamily);
-  static const SolarIconsData conditioner =
-      SolarIconsData(0xeba8, fontFamily: _fontFamily);
-  static const SolarIconsData mirror =
-      SolarIconsData(0xeba9, fontFamily: _fontFamily);
-  static const SolarIconsData remoteController2 =
-      SolarIconsData(0xebaa, fontFamily: _fontFamily);
-  static const SolarIconsData remoteControllerMinimalistic =
-      SolarIconsData(0xebab, fontFamily: _fontFamily);
-  static const SolarIconsData remoteController =
-      SolarIconsData(0xebac, fontFamily: _fontFamily);
-  static const SolarIconsData sofa_2 =
-      SolarIconsData(0xebad, fontFamily: _fontFamily);
-  static const SolarIconsData sofa_3 =
-      SolarIconsData(0xebae, fontFamily: _fontFamily);
-  static const SolarIconsData sofa =
-      SolarIconsData(0xebaf, fontFamily: _fontFamily);
-  static const SolarIconsData speakerMinimalistic =
-      SolarIconsData(0xebb0, fontFamily: _fontFamily);
-  static const SolarIconsData speaker =
-      SolarIconsData(0xebb1, fontFamily: _fontFamily);
-  static const SolarIconsData trellis =
-      SolarIconsData(0xebb2, fontFamily: _fontFamily);
-  static const SolarIconsData washingMachineMinimalistic =
-      SolarIconsData(0xebb3, fontFamily: _fontFamily);
-  static const SolarIconsData washingMachine =
-      SolarIconsData(0xebb4, fontFamily: _fontFamily);
-  static const SolarIconsData bugMinimalistic =
-      SolarIconsData(0xebb5, fontFamily: _fontFamily);
-  static const SolarIconsData bug =
-      SolarIconsData(0xebb6, fontFamily: _fontFamily);
-  static const SolarIconsData code2 =
-      SolarIconsData(0xebb7, fontFamily: _fontFamily);
-  static const SolarIconsData codeCircle =
-      SolarIconsData(0xebb8, fontFamily: _fontFamily);
-  static const SolarIconsData codeSquare =
-      SolarIconsData(0xebb9, fontFamily: _fontFamily);
-  static const SolarIconsData code =
-      SolarIconsData(0xebba, fontFamily: _fontFamily);
-  static const SolarIconsData command =
-      SolarIconsData(0xebbb, fontFamily: _fontFamily);
-  static const SolarIconsData hashtagChat =
-      SolarIconsData(0xebbc, fontFamily: _fontFamily);
-  static const SolarIconsData hashtagCircle =
-      SolarIconsData(0xebbd, fontFamily: _fontFamily);
-  static const SolarIconsData hashtagSquare =
-      SolarIconsData(0xebbe, fontFamily: _fontFamily);
-  static const SolarIconsData hashtag =
-      SolarIconsData(0xebbf, fontFamily: _fontFamily);
-  static const SolarIconsData programming =
-      SolarIconsData(0xebc0, fontFamily: _fontFamily);
-  static const SolarIconsData screencast_2 =
-      SolarIconsData(0xebc1, fontFamily: _fontFamily);
-  static const SolarIconsData screencast =
-      SolarIconsData(0xebc2, fontFamily: _fontFamily);
-  static const SolarIconsData slashCircle =
-      SolarIconsData(0xebc3, fontFamily: _fontFamily);
-  static const SolarIconsData slashSquare =
-      SolarIconsData(0xebc4, fontFamily: _fontFamily);
-  static const SolarIconsData stationMinimalistic =
-      SolarIconsData(0xebc5, fontFamily: _fontFamily);
-  static const SolarIconsData station =
-      SolarIconsData(0xebc6, fontFamily: _fontFamily);
-  static const SolarIconsData structure =
-      SolarIconsData(0xebc7, fontFamily: _fontFamily);
-  static const SolarIconsData translation =
-      SolarIconsData(0xebc8, fontFamily: _fontFamily);
-  static const SolarIconsData sidebarCode =
-      SolarIconsData(0xebc9, fontFamily: _fontFamily);
-  static const SolarIconsData sidebarMinimalistic =
-      SolarIconsData(0xebca, fontFamily: _fontFamily);
-  static const SolarIconsData sidebar =
-      SolarIconsData(0xebcb, fontFamily: _fontFamily);
-  static const SolarIconsData translation_2 =
-      SolarIconsData(0xebcc, fontFamily: _fontFamily);
-  static const SolarIconsData usbCircle =
-      SolarIconsData(0xebcd, fontFamily: _fontFamily);
-  static const SolarIconsData usbSquare =
-      SolarIconsData(0xebce, fontFamily: _fontFamily);
-  static const SolarIconsData usb =
-      SolarIconsData(0xebcf, fontFamily: _fontFamily);
-  static const SolarIconsData wifiRouterMinimalistic =
-      SolarIconsData(0xebd0, fontFamily: _fontFamily);
-  static const SolarIconsData wifiRouterRound =
-      SolarIconsData(0xebd1, fontFamily: _fontFamily);
-  static const SolarIconsData wifiRouter =
-      SolarIconsData(0xebd2, fontFamily: _fontFamily);
-  static const SolarIconsData windowFrame =
-      SolarIconsData(0xebd3, fontFamily: _fontFamily);
-  static const SolarIconsData tuning_2 =
-      SolarIconsData(0xebd4, fontFamily: _fontFamily);
-  static const SolarIconsData tuning_3 =
-      SolarIconsData(0xebd5, fontFamily: _fontFamily);
-  static const SolarIconsData tuning_4 =
-      SolarIconsData(0xebd6, fontFamily: _fontFamily);
-  static const SolarIconsData tuningSquare_2 =
-      SolarIconsData(0xebd7, fontFamily: _fontFamily);
-  static const SolarIconsData tuningSquare =
-      SolarIconsData(0xebd8, fontFamily: _fontFamily);
-  static const SolarIconsData tuning =
-      SolarIconsData(0xebd9, fontFamily: _fontFamily);
-  static const SolarIconsData widget_6 =
-      SolarIconsData(0xebda, fontFamily: _fontFamily);
-  static const SolarIconsData widgetAdd =
-      SolarIconsData(0xebdb, fontFamily: _fontFamily);
-  static const SolarIconsData settingsMinimalistic =
-      SolarIconsData(0xebdc, fontFamily: _fontFamily);
-  static const SolarIconsData settings =
-      SolarIconsData(0xebdd, fontFamily: _fontFamily);
-  static const SolarIconsData widget_2 =
-      SolarIconsData(0xebde, fontFamily: _fontFamily);
-  static const SolarIconsData widget_3 =
-      SolarIconsData(0xebdf, fontFamily: _fontFamily);
-  static const SolarIconsData widget_4 =
-      SolarIconsData(0xebe0, fontFamily: _fontFamily);
-  static const SolarIconsData widget_5 =
-      SolarIconsData(0xebe1, fontFamily: _fontFamily);
-  static const SolarIconsData widget =
-      SolarIconsData(0xebe2, fontFamily: _fontFamily);
-  static const SolarIconsData backspace =
-      SolarIconsData(0xebe3, fontFamily: _fontFamily);
-  static const SolarIconsData linkBrokenMinimalistic =
-      SolarIconsData(0xebe4, fontFamily: _fontFamily);
-  static const SolarIconsData linkBroken =
-      SolarIconsData(0xebe5, fontFamily: _fontFamily);
-  static const SolarIconsData linkCircle =
-      SolarIconsData(0xebe6, fontFamily: _fontFamily);
-  static const SolarIconsData linkMinimalistic_2 =
-      SolarIconsData(0xebe7, fontFamily: _fontFamily);
-  static const SolarIconsData linkMinimalistic =
-      SolarIconsData(0xebe8, fontFamily: _fontFamily);
-  static const SolarIconsData linkRoundAngle =
-      SolarIconsData(0xebe9, fontFamily: _fontFamily);
-  static const SolarIconsData linkRound =
-      SolarIconsData(0xebea, fontFamily: _fontFamily);
-  static const SolarIconsData linkSquare =
-      SolarIconsData(0xebeb, fontFamily: _fontFamily);
-  static const SolarIconsData link =
-      SolarIconsData(0xebec, fontFamily: _fontFamily);
-  static const SolarIconsData paragraphSpacing =
-      SolarIconsData(0xebed, fontFamily: _fontFamily);
-  static const SolarIconsData textBoldSquare =
-      SolarIconsData(0xebee, fontFamily: _fontFamily);
-  static const SolarIconsData textFieldFocus =
-      SolarIconsData(0xebef, fontFamily: _fontFamily);
-  static const SolarIconsData textField =
-      SolarIconsData(0xebf0, fontFamily: _fontFamily);
-  static const SolarIconsData textSelection =
-      SolarIconsData(0xebf1, fontFamily: _fontFamily);
-  static const SolarIconsData textSquare2 =
-      SolarIconsData(0xebf2, fontFamily: _fontFamily);
-  static const SolarIconsData eraserCircle =
-      SolarIconsData(0xebf3, fontFamily: _fontFamily);
-  static const SolarIconsData eraserSquare =
-      SolarIconsData(0xebf4, fontFamily: _fontFamily);
-  static const SolarIconsData eraser =
-      SolarIconsData(0xebf5, fontFamily: _fontFamily);
-  static const SolarIconsData textBoldCircle =
-      SolarIconsData(0xebf6, fontFamily: _fontFamily);
-  static const SolarIconsData textBold =
-      SolarIconsData(0xebf7, fontFamily: _fontFamily);
-  static const SolarIconsData textCircle =
-      SolarIconsData(0xebf8, fontFamily: _fontFamily);
-  static const SolarIconsData textCrossCircle =
-      SolarIconsData(0xebf9, fontFamily: _fontFamily);
-  static const SolarIconsData textCrossSquare =
-      SolarIconsData(0xebfa, fontFamily: _fontFamily);
-  static const SolarIconsData textCross =
-      SolarIconsData(0xebfb, fontFamily: _fontFamily);
-  static const SolarIconsData textItalicCircle =
-      SolarIconsData(0xebfc, fontFamily: _fontFamily);
-  static const SolarIconsData textItalicSquare =
-      SolarIconsData(0xebfd, fontFamily: _fontFamily);
-  static const SolarIconsData textItalic =
-      SolarIconsData(0xebfe, fontFamily: _fontFamily);
-  static const SolarIconsData textSquare =
-      SolarIconsData(0xebff, fontFamily: _fontFamily);
-  static const SolarIconsData textUnderlineCircle =
-      SolarIconsData(0xec00, fontFamily: _fontFamily);
-  static const SolarIconsData textUnderlineCross =
-      SolarIconsData(0xec01, fontFamily: _fontFamily);
-  static const SolarIconsData textUnderline =
-      SolarIconsData(0xec02, fontFamily: _fontFamily);
-  static const SolarIconsData text =
-      SolarIconsData(0xec03, fontFamily: _fontFamily);
-  static const SolarIconsData chart_2 =
-      SolarIconsData(0xec04, fontFamily: _fontFamily);
-  static const SolarIconsData chartSquare =
-      SolarIconsData(0xec05, fontFamily: _fontFamily);
-  static const SolarIconsData chart =
-      SolarIconsData(0xec06, fontFamily: _fontFamily);
-  static const SolarIconsData chatSquare_2 =
-      SolarIconsData(0xec07, fontFamily: _fontFamily);
-  static const SolarIconsData courseDown =
-      SolarIconsData(0xec08, fontFamily: _fontFamily);
-  static const SolarIconsData courseUp =
-      SolarIconsData(0xec09, fontFamily: _fontFamily);
-  static const SolarIconsData diagramDown =
-      SolarIconsData(0xec0a, fontFamily: _fontFamily);
-  static const SolarIconsData diagramUp =
-      SolarIconsData(0xec0b, fontFamily: _fontFamily);
-  static const SolarIconsData graphDownNew =
-      SolarIconsData(0xec0c, fontFamily: _fontFamily);
-  static const SolarIconsData graphDown =
-      SolarIconsData(0xec0d, fontFamily: _fontFamily);
-  static const SolarIconsData graphNewUp =
-      SolarIconsData(0xec0e, fontFamily: _fontFamily);
-  static const SolarIconsData graphNew =
-      SolarIconsData(0xec0f, fontFamily: _fontFamily);
-  static const SolarIconsData graphUp =
-      SolarIconsData(0xec10, fontFamily: _fontFamily);
-  static const SolarIconsData graph =
-      SolarIconsData(0xec11, fontFamily: _fontFamily);
-  static const SolarIconsData pieChart2 =
-      SolarIconsData(0xec12, fontFamily: _fontFamily);
-  static const SolarIconsData pieChart3 =
-      SolarIconsData(0xec13, fontFamily: _fontFamily);
-  static const SolarIconsData pieChart =
-      SolarIconsData(0xec14, fontFamily: _fontFamily);
-  static const SolarIconsData presentationGraph =
-      SolarIconsData(0xec15, fontFamily: _fontFamily);
-  static const SolarIconsData roundGraph =
-      SolarIconsData(0xec16, fontFamily: _fontFamily);
-  static const SolarIconsData bag5 =
-      SolarIconsData(0xec17, fontFamily: _fontFamily);
-  static const SolarIconsData bagHeart =
-      SolarIconsData(0xec18, fontFamily: _fontFamily);
-  static const SolarIconsData bagMusic_2 =
-      SolarIconsData(0xec19, fontFamily: _fontFamily);
-  static const SolarIconsData bagSmile =
-      SolarIconsData(0xec1a, fontFamily: _fontFamily);
-  static const SolarIconsData shop_2 =
-      SolarIconsData(0xec1b, fontFamily: _fontFamily);
-  static const SolarIconsData shopMinimalistic =
-      SolarIconsData(0xec1c, fontFamily: _fontFamily);
-  static const SolarIconsData shop =
-      SolarIconsData(0xec1d, fontFamily: _fontFamily);
-  static const SolarIconsData bag2 =
-      SolarIconsData(0xec1e, fontFamily: _fontFamily);
-  static const SolarIconsData bag3 =
-      SolarIconsData(0xec1f, fontFamily: _fontFamily);
-  static const SolarIconsData bag4 =
-      SolarIconsData(0xec20, fontFamily: _fontFamily);
-  static const SolarIconsData bagCheck =
-      SolarIconsData(0xec21, fontFamily: _fontFamily);
-  static const SolarIconsData bagCross =
-      SolarIconsData(0xec22, fontFamily: _fontFamily);
-  static const SolarIconsData bagMusic =
-      SolarIconsData(0xec23, fontFamily: _fontFamily);
-  static const SolarIconsData bag =
-      SolarIconsData(0xec24, fontFamily: _fontFamily);
-  static const SolarIconsData cart_2 =
-      SolarIconsData(0xec25, fontFamily: _fontFamily);
-  static const SolarIconsData cart_3 =
-      SolarIconsData(0xec26, fontFamily: _fontFamily);
-  static const SolarIconsData cart_4 =
-      SolarIconsData(0xec27, fontFamily: _fontFamily);
-  static const SolarIconsData cart_5 =
-      SolarIconsData(0xec28, fontFamily: _fontFamily);
-  static const SolarIconsData cartCheck =
-      SolarIconsData(0xec29, fontFamily: _fontFamily);
-  static const SolarIconsData cartCross =
-      SolarIconsData(0xec2a, fontFamily: _fontFamily);
-  static const SolarIconsData cartLarge2 =
-      SolarIconsData(0xec2b, fontFamily: _fontFamily);
-  static const SolarIconsData cartLarge3 =
-      SolarIconsData(0xec2c, fontFamily: _fontFamily);
-  static const SolarIconsData cartLarge_4 =
-      SolarIconsData(0xec2d, fontFamily: _fontFamily);
-  static const SolarIconsData cartLargeMinimalistic =
-      SolarIconsData(0xec2e, fontFamily: _fontFamily);
-  static const SolarIconsData cartLarge =
-      SolarIconsData(0xec2f, fontFamily: _fontFamily);
-  static const SolarIconsData cartPlus =
-      SolarIconsData(0xec30, fontFamily: _fontFamily);
-  static const SolarIconsData cart =
-      SolarIconsData(0xec31, fontFamily: _fontFamily);
-  static const SolarIconsData bonfire =
-      SolarIconsData(0xec32, fontFamily: _fontFamily);
-  static const SolarIconsData fireMinimalistic =
-      SolarIconsData(0xec33, fontFamily: _fontFamily);
-  static const SolarIconsData fireSquare =
-      SolarIconsData(0xec34, fontFamily: _fontFamily);
-  static const SolarIconsData fire =
-      SolarIconsData(0xec35, fontFamily: _fontFamily);
-  static const SolarIconsData flame =
-      SolarIconsData(0xec36, fontFamily: _fontFamily);
-  static const SolarIconsData leaf =
-      SolarIconsData(0xec37, fontFamily: _fontFamily);
-  static const SolarIconsData suitcaseLines =
-      SolarIconsData(0xec38, fontFamily: _fontFamily);
-  static const SolarIconsData suitcaseTag =
-      SolarIconsData(0xec39, fontFamily: _fontFamily);
-  static const SolarIconsData suitcase =
-      SolarIconsData(0xec3a, fontFamily: _fontFamily);
-  static const SolarIconsData backpack =
-      SolarIconsData(0xec3b, fontFamily: _fontFamily);
-  static const SolarIconsData book2 =
-      SolarIconsData(0xec3c, fontFamily: _fontFamily);
-  static const SolarIconsData bookBookmarkMinimalistic =
-      SolarIconsData(0xec3d, fontFamily: _fontFamily);
-  static const SolarIconsData bookBookmark =
-      SolarIconsData(0xec3e, fontFamily: _fontFamily);
-  static const SolarIconsData bookMinimalistic =
-      SolarIconsData(0xec3f, fontFamily: _fontFamily);
-  static const SolarIconsData bookmarkCircle =
-      SolarIconsData(0xec40, fontFamily: _fontFamily);
-  static const SolarIconsData bookmarkOpened =
-      SolarIconsData(0xec41, fontFamily: _fontFamily);
-  static const SolarIconsData bookmarkSquareMinimalistic =
-      SolarIconsData(0xec42, fontFamily: _fontFamily);
-  static const SolarIconsData bookmarkSquare =
-      SolarIconsData(0xec43, fontFamily: _fontFamily);
-  static const SolarIconsData bookmark =
-      SolarIconsData(0xec44, fontFamily: _fontFamily);
-  static const SolarIconsData calculatorMinimalistic =
-      SolarIconsData(0xec45, fontFamily: _fontFamily);
-  static const SolarIconsData calculator =
-      SolarIconsData(0xec46, fontFamily: _fontFamily);
-  static const SolarIconsData document =
-      SolarIconsData(0xec47, fontFamily: _fontFamily);
-  static const SolarIconsData passportMinimalistic =
-      SolarIconsData(0xec48, fontFamily: _fontFamily);
-  static const SolarIconsData passport =
-      SolarIconsData(0xec49, fontFamily: _fontFamily);
-  static const SolarIconsData plus =
-      SolarIconsData(0xec4a, fontFamily: _fontFamily);
-  static const SolarIconsData minus =
-      SolarIconsData(0xec4a, fontFamily: _fontFamily);
-  static const SolarIconsData book =
-      SolarIconsData(0xec4b, fontFamily: _fontFamily);
-  static const SolarIconsData caseMinimalistic =
-      SolarIconsData(0xec4c, fontFamily: _fontFamily);
-  static const SolarIconsData caseRoundMinimalistic =
-      SolarIconsData(0xec4d, fontFamily: _fontFamily);
-  static const SolarIconsData caseRound =
-      SolarIconsData(0xec4e, fontFamily: _fontFamily);
-  static const SolarIconsData case_ =
-      SolarIconsData(0xec4f, fontFamily: _fontFamily);
-  static const SolarIconsData diplomaVerified =
-      SolarIconsData(0xec50, fontFamily: _fontFamily);
-  static const SolarIconsData diploma =
-      SolarIconsData(0xec51, fontFamily: _fontFamily);
-  static const SolarIconsData notebookBookmark =
-      SolarIconsData(0xec52, fontFamily: _fontFamily);
-  static const SolarIconsData notebookMinimalistic =
-      SolarIconsData(0xec53, fontFamily: _fontFamily);
-  static const SolarIconsData notebookSquare =
-      SolarIconsData(0xec54, fontFamily: _fontFamily);
-  static const SolarIconsData notebook =
-      SolarIconsData(0xec55, fontFamily: _fontFamily);
-  static const SolarIconsData squareAcademicCap2 =
-      SolarIconsData(0xec56, fontFamily: _fontFamily);
-  static const SolarIconsData squareAcademicCap =
-      SolarIconsData(0xec57, fontFamily: _fontFamily);
-  static const SolarIconsData alignBottom =
-      SolarIconsData(0xec58, fontFamily: _fontFamily);
-  static const SolarIconsData alignHorizontalSpacing =
-      SolarIconsData(0xec59, fontFamily: _fontFamily);
-  static const SolarIconsData alignHorizontalCenter =
-      SolarIconsData(0xec5a, fontFamily: _fontFamily);
-  static const SolarIconsData alignLeft =
-      SolarIconsData(0xec5b, fontFamily: _fontFamily);
-  static const SolarIconsData alignRight =
-      SolarIconsData(0xec5c, fontFamily: _fontFamily);
-  static const SolarIconsData alignTop =
-      SolarIconsData(0xec5d, fontFamily: _fontFamily);
-  static const SolarIconsData alignVerticalCenter =
-      SolarIconsData(0xec5e, fontFamily: _fontFamily);
-  static const SolarIconsData alignVerticalSpacing =
-      SolarIconsData(0xec5f, fontFamily: _fontFamily);
-  static const SolarIconsData cropMinimalistic =
-      SolarIconsData(0xec60, fontFamily: _fontFamily);
-  static const SolarIconsData crop =
-      SolarIconsData(0xec61, fontFamily: _fontFamily);
-  static const SolarIconsData layersMinimalistic =
-      SolarIconsData(0xec62, fontFamily: _fontFamily);
-  static const SolarIconsData layers =
-      SolarIconsData(0xec63, fontFamily: _fontFamily);
-  static const SolarIconsData paintRoller =
-      SolarIconsData(0xec64, fontFamily: _fontFamily);
-  static const SolarIconsData paletteRound =
-      SolarIconsData(0xec65, fontFamily: _fontFamily);
-  static const SolarIconsData palette =
-      SolarIconsData(0xec66, fontFamily: _fontFamily);
-  static const SolarIconsData palette2 =
-      SolarIconsData(0xec67, fontFamily: _fontFamily);
-  static const SolarIconsData colourTuning =
-      SolarIconsData(0xec68, fontFamily: _fontFamily);
-  static const SolarIconsData filters =
-      SolarIconsData(0xec69, fontFamily: _fontFamily);
-  static const SolarIconsData flipHorizontal =
-      SolarIconsData(0xec6a, fontFamily: _fontFamily);
-  static const SolarIconsData flipVertical =
-      SolarIconsData(0xec6b, fontFamily: _fontFamily);
-  static const SolarIconsData mirrorLeft =
-      SolarIconsData(0xec6c, fontFamily: _fontFamily);
-  static const SolarIconsData mirrorRight =
-      SolarIconsData(0xec6d, fontFamily: _fontFamily);
-  static const SolarIconsData pipette =
-      SolarIconsData(0xec6e, fontFamily: _fontFamily);
-  static const SolarIconsData radialBlur =
-      SolarIconsData(0xec6f, fontFamily: _fontFamily);
-  static const SolarIconsData rulerAngular =
-      SolarIconsData(0xec70, fontFamily: _fontFamily);
-  static const SolarIconsData rulerCrossPen =
-      SolarIconsData(0xec71, fontFamily: _fontFamily);
-  static const SolarIconsData rulerPen =
-      SolarIconsData(0xec72, fontFamily: _fontFamily);
-  static const SolarIconsData ruler =
-      SolarIconsData(0xec73, fontFamily: _fontFamily);
-  static const SolarIconsData threeSquares =
-      SolarIconsData(0xec74, fontFamily: _fontFamily);
-  static const SolarIconsData dislike =
-      SolarIconsData(0xec75, fontFamily: _fontFamily);
-  static const SolarIconsData heartAngle =
-      SolarIconsData(0xec76, fontFamily: _fontFamily);
-  static const SolarIconsData heartBroken =
-      SolarIconsData(0xec77, fontFamily: _fontFamily);
-  static const SolarIconsData heartLock =
-      SolarIconsData(0xec78, fontFamily: _fontFamily);
-  static const SolarIconsData heartShine =
-      SolarIconsData(0xec79, fontFamily: _fontFamily);
-  static const SolarIconsData heartUnlock =
-      SolarIconsData(0xec7a, fontFamily: _fontFamily);
-  static const SolarIconsData heart =
-      SolarIconsData(0xec7b, fontFamily: _fontFamily);
-  static const SolarIconsData hearts =
-      SolarIconsData(0xec7c, fontFamily: _fontFamily);
-  static const SolarIconsData like =
-      SolarIconsData(0xec7d, fontFamily: _fontFamily);
-  static const SolarIconsData medalRibbonStar =
-      SolarIconsData(0xec7e, fontFamily: _fontFamily);
-  static const SolarIconsData medalRibbon =
-      SolarIconsData(0xec7f, fontFamily: _fontFamily);
-  static const SolarIconsData medalRibbonsStart =
-      SolarIconsData(0xec80, fontFamily: _fontFamily);
-  static const SolarIconsData medalStarCircle =
-      SolarIconsData(0xec81, fontFamily: _fontFamily);
-  static const SolarIconsData medalStarSquare =
-      SolarIconsData(0xec82, fontFamily: _fontFamily);
-  static const SolarIconsData medalStar =
-      SolarIconsData(0xec83, fontFamily: _fontFamily);
-  static const SolarIconsData startShine =
-      SolarIconsData(0xec84, fontFamily: _fontFamily);
-  static const SolarIconsData start1 =
-      SolarIconsData(0xec85, fontFamily: _fontFamily);
-  static const SolarIconsData corkscrew =
-      SolarIconsData(0xec86, fontFamily: _fontFamily);
-  static const SolarIconsData ladle =
-      SolarIconsData(0xec87, fontFamily: _fontFamily);
-  static const SolarIconsData ovenMittsMinimalistic =
-      SolarIconsData(0xec88, fontFamily: _fontFamily);
-  static const SolarIconsData ovenMitts =
-      SolarIconsData(0xec89, fontFamily: _fontFamily);
-  static const SolarIconsData rollingPin =
-      SolarIconsData(0xec8a, fontFamily: _fontFamily);
-  static const SolarIconsData whisk =
-      SolarIconsData(0xec8b, fontFamily: _fontFamily);
-  static const SolarIconsData bottle =
-      SolarIconsData(0xec8c, fontFamily: _fontFamily);
-  static const SolarIconsData chefHatHeart =
-      SolarIconsData(0xec8d, fontFamily: _fontFamily);
-  static const SolarIconsData chefHatMinimalistic =
-      SolarIconsData(0xec8e, fontFamily: _fontFamily);
-  static const SolarIconsData chefHat =
-      SolarIconsData(0xec8f, fontFamily: _fontFamily);
-  static const SolarIconsData cupHot =
-      SolarIconsData(0xec90, fontFamily: _fontFamily);
-  static const SolarIconsData cupPaper =
-      SolarIconsData(0xec91, fontFamily: _fontFamily);
-  static const SolarIconsData cup =
-      SolarIconsData(0xec92, fontFamily: _fontFamily);
-  static const SolarIconsData donutBitten =
-      SolarIconsData(0xec93, fontFamily: _fontFamily);
-  static const SolarIconsData donut =
-      SolarIconsData(0xec94, fontFamily: _fontFamily);
-  static const SolarIconsData teaCup =
-      SolarIconsData(0xec95, fontFamily: _fontFamily);
-  static const SolarIconsData wineglassTriangle =
-      SolarIconsData(0xec96, fontFamily: _fontFamily);
-  static const SolarIconsData wineglass =
-      SolarIconsData(0xec97, fontFamily: _fontFamily);
-  static const SolarIconsData arrowToDownLeft =
-      SolarIconsData(0xec98, fontFamily: _fontFamily);
-  static const SolarIconsData arrowToDownRight =
-      SolarIconsData(0xec99, fontFamily: _fontFamily);
-  static const SolarIconsData arrowToTopLeft =
-      SolarIconsData(0xec9a, fontFamily: _fontFamily);
-  static const SolarIconsData arrowToTopRight =
-      SolarIconsData(0xec9b, fontFamily: _fontFamily);
-  static const SolarIconsData downloadMinimalistic =
-      SolarIconsData(0xec9c, fontFamily: _fontFamily);
-  static const SolarIconsData download =
-      SolarIconsData(0xec9d, fontFamily: _fontFamily);
-  static const SolarIconsData exit =
-      SolarIconsData(0xec9e, fontFamily: _fontFamily);
-  static const SolarIconsData export =
-      SolarIconsData(0xec9f, fontFamily: _fontFamily);
-  static const SolarIconsData forward_2 =
-      SolarIconsData(0xeca0, fontFamily: _fontFamily);
-  static const SolarIconsData forward1 =
-      SolarIconsData(0xeca1, fontFamily: _fontFamily);
-  static const SolarIconsData import =
-      SolarIconsData(0xeca2, fontFamily: _fontFamily);
-  static const SolarIconsData login_2 =
-      SolarIconsData(0xeca3, fontFamily: _fontFamily);
-  static const SolarIconsData login_3 =
-      SolarIconsData(0xeca4, fontFamily: _fontFamily);
-  static const SolarIconsData login =
-      SolarIconsData(0xeca5, fontFamily: _fontFamily);
-  static const SolarIconsData logout_2 =
-      SolarIconsData(0xeca6, fontFamily: _fontFamily);
-  static const SolarIconsData logout_3 =
-      SolarIconsData(0xeca7, fontFamily: _fontFamily);
-  static const SolarIconsData logout =
-      SolarIconsData(0xeca8, fontFamily: _fontFamily);
-  static const SolarIconsData maximizeSquare2 =
-      SolarIconsData(0xeca9, fontFamily: _fontFamily);
-  static const SolarIconsData minimizeSquare2 =
-      SolarIconsData(0xecaa, fontFamily: _fontFamily);
-  static const SolarIconsData minimizeSquareMinimalistic =
-      SolarIconsData(0xecab, fontFamily: _fontFamily);
-  static const SolarIconsData reply_2 =
-      SolarIconsData(0xecac, fontFamily: _fontFamily);
-  static const SolarIconsData reply =
-      SolarIconsData(0xecad, fontFamily: _fontFamily);
-  static const SolarIconsData screenShare =
-      SolarIconsData(0xecae, fontFamily: _fontFamily);
-  static const SolarIconsData uploadMinimalistic =
-      SolarIconsData(0xecaf, fontFamily: _fontFamily);
-  static const SolarIconsData upload =
-      SolarIconsData(0xecb0, fontFamily: _fontFamily);
-  static const SolarIconsData circleBottomDown =
-      SolarIconsData(0xecb1, fontFamily: _fontFamily);
-  static const SolarIconsData circleBottomUp =
-      SolarIconsData(0xecb2, fontFamily: _fontFamily);
-  static const SolarIconsData circleTopDown =
-      SolarIconsData(0xecb3, fontFamily: _fontFamily);
-  static const SolarIconsData circleTopUp =
-      SolarIconsData(0xecb4, fontFamily: _fontFamily);
-  static const SolarIconsData downloadSquare =
-      SolarIconsData(0xecb5, fontFamily: _fontFamily);
-  static const SolarIconsData maximizeSquare3 =
-      SolarIconsData(0xecb6, fontFamily: _fontFamily);
-  static const SolarIconsData maximizeSquareMinimalistic =
-      SolarIconsData(0xecb7, fontFamily: _fontFamily);
-  static const SolarIconsData maximizeSquare =
-      SolarIconsData(0xecb8, fontFamily: _fontFamily);
-  static const SolarIconsData maximize =
-      SolarIconsData(0xecb9, fontFamily: _fontFamily);
-  static const SolarIconsData minimizeSquare3 =
-      SolarIconsData(0xecba, fontFamily: _fontFamily);
-  static const SolarIconsData minimizeSquare =
-      SolarIconsData(0xecbb, fontFamily: _fontFamily);
-  static const SolarIconsData minimize =
-      SolarIconsData(0xecbc, fontFamily: _fontFamily);
-  static const SolarIconsData receiveSquare =
-      SolarIconsData(0xecbd, fontFamily: _fontFamily);
-  static const SolarIconsData reorder =
-      SolarIconsData(0xecbe, fontFamily: _fontFamily);
-  static const SolarIconsData scale =
-      SolarIconsData(0xecbf, fontFamily: _fontFamily);
-  static const SolarIconsData squareBottomDown =
-      SolarIconsData(0xecc0, fontFamily: _fontFamily);
-  static const SolarIconsData squareBottomUp =
-      SolarIconsData(0xecc1, fontFamily: _fontFamily);
-  static const SolarIconsData squareTopDown =
-      SolarIconsData(0xecc2, fontFamily: _fontFamily);
-  static const SolarIconsData squareTopUp =
-      SolarIconsData(0xecc3, fontFamily: _fontFamily);
-  static const SolarIconsData undoLeftRoundSquare =
-      SolarIconsData(0xecc4, fontFamily: _fontFamily);
-  static const SolarIconsData undoLeftRound =
-      SolarIconsData(0xecc5, fontFamily: _fontFamily);
-  static const SolarIconsData undoLeftSquare =
-      SolarIconsData(0xecc6, fontFamily: _fontFamily);
-  static const SolarIconsData undoLeft =
-      SolarIconsData(0xecc7, fontFamily: _fontFamily);
-  static const SolarIconsData undoRightRoundSquare =
-      SolarIconsData(0xecc8, fontFamily: _fontFamily);
-  static const SolarIconsData undoRightRound =
-      SolarIconsData(0xecc9, fontFamily: _fontFamily);
-  static const SolarIconsData undoRightSquare =
-      SolarIconsData(0xecca, fontFamily: _fontFamily);
-  static const SolarIconsData undoRight =
-      SolarIconsData(0xeccb, fontFamily: _fontFamily);
-  static const SolarIconsData uploadSquare =
-      SolarIconsData(0xeccc, fontFamily: _fontFamily);
-  static const SolarIconsData downloadTwiceSquare =
-      SolarIconsData(0xeccd, fontFamily: _fontFamily);
-  static const SolarIconsData receiveTwiceSquare =
-      SolarIconsData(0xecce, fontFamily: _fontFamily);
-  static const SolarIconsData sendSquare =
-      SolarIconsData(0xeccf, fontFamily: _fontFamily);
-  static const SolarIconsData sendTwiceSquare =
-      SolarIconsData(0xecd0, fontFamily: _fontFamily);
-  static const SolarIconsData uploadTwiceSquare =
-      SolarIconsData(0xecd1, fontFamily: _fontFamily);
-  static const SolarIconsData bellBing =
-      SolarIconsData(0xecd2, fontFamily: _fontFamily);
-  static const SolarIconsData bellOff =
-      SolarIconsData(0xecd3, fontFamily: _fontFamily);
-  static const SolarIconsData bell =
-      SolarIconsData(0xecd4, fontFamily: _fontFamily);
-  static const SolarIconsData notificationLinesRemove =
-      SolarIconsData(0xecd5, fontFamily: _fontFamily);
-  static const SolarIconsData notificationRemove =
-      SolarIconsData(0xecd6, fontFamily: _fontFamily);
-  static const SolarIconsData notificationUnreadLines =
-      SolarIconsData(0xecd7, fontFamily: _fontFamily);
-  static const SolarIconsData notificationUnread =
-      SolarIconsData(0xecd8, fontFamily: _fontFamily);
-  static const SolarIconsData archiveCheck =
-      SolarIconsData(0xecd9, fontFamily: _fontFamily);
-  static const SolarIconsData archiveDownMinimalistic =
-      SolarIconsData(0xecda, fontFamily: _fontFamily);
-  static const SolarIconsData archiveDown =
-      SolarIconsData(0xecdb, fontFamily: _fontFamily);
-  static const SolarIconsData archiveMinimalistic =
-      SolarIconsData(0xecdc, fontFamily: _fontFamily);
-  static const SolarIconsData archiveUpMinimalistic =
-      SolarIconsData(0xecdd, fontFamily: _fontFamily);
-  static const SolarIconsData archiveUp =
-      SolarIconsData(0xecde, fontFamily: _fontFamily);
-  static const SolarIconsData archive =
-      SolarIconsData(0xecdf, fontFamily: _fontFamily);
-  static const SolarIconsData clipboardAdd =
-      SolarIconsData(0xece0, fontFamily: _fontFamily);
-  static const SolarIconsData clipboardCheck =
-      SolarIconsData(0xece1, fontFamily: _fontFamily);
-  static const SolarIconsData clipboardHeart =
-      SolarIconsData(0xece2, fontFamily: _fontFamily);
-  static const SolarIconsData clipboardList =
-      SolarIconsData(0xece3, fontFamily: _fontFamily);
-  static const SolarIconsData clipboardRemove =
-      SolarIconsData(0xece4, fontFamily: _fontFamily);
-  static const SolarIconsData clipboardText =
-      SolarIconsData(0xece5, fontFamily: _fontFamily);
-  static const SolarIconsData clipboard =
-      SolarIconsData(0xece6, fontFamily: _fontFamily);
-  static const SolarIconsData documentsMinimalistic =
-      SolarIconsData(0xece7, fontFamily: _fontFamily);
-  static const SolarIconsData notebook1 =
-      SolarIconsData(0xece8, fontFamily: _fontFamily);
-  static const SolarIconsData notesMinimalistic =
-      SolarIconsData(0xece9, fontFamily: _fontFamily);
-  static const SolarIconsData notes =
-      SolarIconsData(0xecea, fontFamily: _fontFamily);
-  static const SolarIconsData documentAdd =
-      SolarIconsData(0xeceb, fontFamily: _fontFamily);
-  static const SolarIconsData documentMedicine =
-      SolarIconsData(0xecec, fontFamily: _fontFamily);
-  static const SolarIconsData documentText =
-      SolarIconsData(0xeced, fontFamily: _fontFamily);
-  static const SolarIconsData document1 =
-      SolarIconsData(0xecee, fontFamily: _fontFamily);
-  static const SolarIconsData documents =
-      SolarIconsData(0xecef, fontFamily: _fontFamily);
-  static const SolarIconsData codeScan =
-      SolarIconsData(0xecf0, fontFamily: _fontFamily);
-  static const SolarIconsData eyeScan =
-      SolarIconsData(0xecf1, fontFamily: _fontFamily);
-  static const SolarIconsData objectScan =
-      SolarIconsData(0xecf2, fontFamily: _fontFamily);
-  static const SolarIconsData qrCode =
-      SolarIconsData(0xecf3, fontFamily: _fontFamily);
-  static const SolarIconsData scanner_2 =
-      SolarIconsData(0xecf4, fontFamily: _fontFamily);
-  static const SolarIconsData scanner =
-      SolarIconsData(0xecf5, fontFamily: _fontFamily);
-  static const SolarIconsData shieldCheck =
-      SolarIconsData(0xecf6, fontFamily: _fontFamily);
-  static const SolarIconsData shieldCross =
-      SolarIconsData(0xecf7, fontFamily: _fontFamily);
-  static const SolarIconsData shieldKeyholeMinimalistic =
-      SolarIconsData(0xecf8, fontFamily: _fontFamily);
-  static const SolarIconsData shieldKeyhole =
-      SolarIconsData(0xecf9, fontFamily: _fontFamily);
-  static const SolarIconsData shieldMinus =
-      SolarIconsData(0xecfa, fontFamily: _fontFamily);
-  static const SolarIconsData shieldNetwork =
-      SolarIconsData(0xecfb, fontFamily: _fontFamily);
-  static const SolarIconsData shieldPlus =
-      SolarIconsData(0xecfc, fontFamily: _fontFamily);
-  static const SolarIconsData shieldStar =
-      SolarIconsData(0xecfd, fontFamily: _fontFamily);
-  static const SolarIconsData shieldUp =
-      SolarIconsData(0xecfe, fontFamily: _fontFamily);
-  static const SolarIconsData shieldUser =
-      SolarIconsData(0xecff, fontFamily: _fontFamily);
-  static const SolarIconsData shieldWarning =
-      SolarIconsData(0xed00, fontFamily: _fontFamily);
-  static const SolarIconsData bombEmoji =
-      SolarIconsData(0xed01, fontFamily: _fontFamily);
-  static const SolarIconsData bombMinimalistic =
-      SolarIconsData(0xed02, fontFamily: _fontFamily);
-  static const SolarIconsData bomb =
-      SolarIconsData(0xed03, fontFamily: _fontFamily);
-  static const SolarIconsData eyeClosed =
-      SolarIconsData(0xed04, fontFamily: _fontFamily);
-  static const SolarIconsData eye =
-      SolarIconsData(0xed05, fontFamily: _fontFamily);
-  static const SolarIconsData incognito =
-      SolarIconsData(0xed06, fontFamily: _fontFamily);
-  static const SolarIconsData keyMinimalistic2 =
-      SolarIconsData(0xed07, fontFamily: _fontFamily);
-  static const SolarIconsData keyMinimalisticSquare_2 =
-      SolarIconsData(0xed08, fontFamily: _fontFamily);
-  static const SolarIconsData keyMinimalisticSquare_3 =
-      SolarIconsData(0xed09, fontFamily: _fontFamily);
-  static const SolarIconsData keyMinimalisticSquare =
-      SolarIconsData(0xed0a, fontFamily: _fontFamily);
-  static const SolarIconsData keyMinimalistic =
-      SolarIconsData(0xed0b, fontFamily: _fontFamily);
-  static const SolarIconsData keySquare_2 =
-      SolarIconsData(0xed0c, fontFamily: _fontFamily);
-  static const SolarIconsData keySquare =
-      SolarIconsData(0xed0d, fontFamily: _fontFamily);
-  static const SolarIconsData key =
-      SolarIconsData(0xed0e, fontFamily: _fontFamily);
-  static const SolarIconsData lockKeyholeMinimalisticUnlocked =
-      SolarIconsData(0xed0f, fontFamily: _fontFamily);
-  static const SolarIconsData lockKeyholeMinimalistic =
-      SolarIconsData(0xed10, fontFamily: _fontFamily);
-  static const SolarIconsData lockKeyholeUnlocked =
-      SolarIconsData(0xed11, fontFamily: _fontFamily);
-  static const SolarIconsData lockKeyhole =
-      SolarIconsData(0xed12, fontFamily: _fontFamily);
-  static const SolarIconsData lockPassword_ =
-      SolarIconsData(0xed13, fontFamily: _fontFamily);
-  static const SolarIconsData lockPassword =
-      SolarIconsData(0xed14, fontFamily: _fontFamily);
-  static const SolarIconsData lockUnlocked =
-      SolarIconsData(0xed15, fontFamily: _fontFamily);
-  static const SolarIconsData lock =
-      SolarIconsData(0xed16, fontFamily: _fontFamily);
-  static const SolarIconsData passwordMinimalisticInput =
-      SolarIconsData(0xed17, fontFamily: _fontFamily);
-  static const SolarIconsData passwordMinimalistic =
-      SolarIconsData(0xed18, fontFamily: _fontFamily);
-  static const SolarIconsData password =
-      SolarIconsData(0xed19, fontFamily: _fontFamily);
-  static const SolarIconsData shieldMinimalistic =
-      SolarIconsData(0xed1a, fontFamily: _fontFamily);
-  static const SolarIconsData shield =
-      SolarIconsData(0xed1b, fontFamily: _fontFamily);
-  static const SolarIconsData sirenRounded =
-      SolarIconsData(0xed1c, fontFamily: _fontFamily);
-  static const SolarIconsData siren =
-      SolarIconsData(0xed1d, fontFamily: _fontFamily);
-  static const SolarIconsData boltCircle =
-      SolarIconsData(0xed1e, fontFamily: _fontFamily);
-  static const SolarIconsData bolt =
-      SolarIconsData(0xed1f, fontFamily: _fontFamily);
-  static const SolarIconsData confettiMinimalistic =
-      SolarIconsData(0xed20, fontFamily: _fontFamily);
-  static const SolarIconsData confetti =
-      SolarIconsData(0xed21, fontFamily: _fontFamily);
-  static const SolarIconsData maskHapply =
-      SolarIconsData(0xed22, fontFamily: _fontFamily);
-  static const SolarIconsData masks =
-      SolarIconsData(0xed23, fontFamily: _fontFamily);
-  static const SolarIconsData mentionCircle =
-      SolarIconsData(0xed24, fontFamily: _fontFamily);
-  static const SolarIconsData mentionSquare =
-      SolarIconsData(0xed25, fontFamily: _fontFamily);
-  static const SolarIconsData trashBin2 =
-      SolarIconsData(0xed26, fontFamily: _fontFamily);
-  static const SolarIconsData trashBinTrash =
-      SolarIconsData(0xed27, fontFamily: _fontFamily);
-  static const SolarIconsData accessibility =
-      SolarIconsData(0xed28, fontFamily: _fontFamily);
-  static const SolarIconsData body =
-      SolarIconsData(0xed29, fontFamily: _fontFamily);
-  static const SolarIconsData boxMinimalistic =
-      SolarIconsData(0xed2a, fontFamily: _fontFamily);
-  static const SolarIconsData box =
-      SolarIconsData(0xed2b, fontFamily: _fontFamily);
-  static const SolarIconsData cosmetic =
-      SolarIconsData(0xed2c, fontFamily: _fontFamily);
-  static const SolarIconsData cursorSquare =
-      SolarIconsData(0xed2d, fontFamily: _fontFamily);
-  static const SolarIconsData cursor =
-      SolarIconsData(0xed2e, fontFamily: _fontFamily);
-  static const SolarIconsData delivery =
-      SolarIconsData(0xed2f, fontFamily: _fontFamily);
-  static const SolarIconsData feed =
-      SolarIconsData(0xed30, fontFamily: _fontFamily);
-  static const SolarIconsData ferrisWheel =
-      SolarIconsData(0xed31, fontFamily: _fontFamily);
-  static const SolarIconsData flashlightOn =
-      SolarIconsData(0xed32, fontFamily: _fontFamily);
-  static const SolarIconsData flashlight =
-      SolarIconsData(0xed33, fontFamily: _fontFamily);
-  static const SolarIconsData gift =
-      SolarIconsData(0xed34, fontFamily: _fontFamily);
-  static const SolarIconsData hanger_2 =
-      SolarIconsData(0xed35, fontFamily: _fontFamily);
-  static const SolarIconsData hanger =
-      SolarIconsData(0xed36, fontFamily: _fontFamily);
-  static const SolarIconsData magicStick_2 =
-      SolarIconsData(0xed37, fontFamily: _fontFamily);
-  static const SolarIconsData magicStick_3 =
-      SolarIconsData(0xed38, fontFamily: _fontFamily);
-  static const SolarIconsData magicStick =
-      SolarIconsData(0xed39, fontFamily: _fontFamily);
-  static const SolarIconsData magnetWave =
-      SolarIconsData(0xed3a, fontFamily: _fontFamily);
-  static const SolarIconsData magnet =
-      SolarIconsData(0xed3b, fontFamily: _fontFamily);
-  static const SolarIconsData maskSad =
-      SolarIconsData(0xed3c, fontFamily: _fontFamily);
-  static const SolarIconsData mirror1 =
-      SolarIconsData(0xed3d, fontFamily: _fontFamily);
-  static const SolarIconsData perfume =
-      SolarIconsData(0xed3e, fontFamily: _fontFamily);
-  static const SolarIconsData scissorsSquare =
-      SolarIconsData(0xed3f, fontFamily: _fontFamily);
-  static const SolarIconsData skirt =
-      SolarIconsData(0xed40, fontFamily: _fontFamily);
-  static const SolarIconsData sledgehammer =
-      SolarIconsData(0xed41, fontFamily: _fontFamily);
-  static const SolarIconsData sleeping =
-      SolarIconsData(0xed42, fontFamily: _fontFamily);
-  static const SolarIconsData tShirt =
-      SolarIconsData(0xed43, fontFamily: _fontFamily);
-  static const SolarIconsData k =
-      SolarIconsData(0xed44, fontFamily: _fontFamily);
-  static const SolarIconsData augmentedReality =
-      SolarIconsData(0xed45, fontFamily: _fontFamily);
-  static const SolarIconsData balloon =
-      SolarIconsData(0xed46, fontFamily: _fontFamily);
-  static const SolarIconsData copyright =
-      SolarIconsData(0xed47, fontFamily: _fontFamily);
-  static const SolarIconsData creativeCommons =
-      SolarIconsData(0xed48, fontFamily: _fontFamily);
-  static const SolarIconsData cupFirst =
-      SolarIconsData(0xed49, fontFamily: _fontFamily);
-  static const SolarIconsData cupMusic =
-      SolarIconsData(0xed4a, fontFamily: _fontFamily);
-  static const SolarIconsData cupStar =
-      SolarIconsData(0xed4b, fontFamily: _fontFamily);
-  static const SolarIconsData cup1 =
-      SolarIconsData(0xed4c, fontFamily: _fontFamily);
-  static const SolarIconsData explicit =
-      SolarIconsData(0xed4d, fontFamily: _fontFamily);
-  static const SolarIconsData figma =
-      SolarIconsData(0xed4e, fontFamily: _fontFamily);
-  static const SolarIconsData filter =
-      SolarIconsData(0xed4f, fontFamily: _fontFamily);
-  static const SolarIconsData flag_2 =
-      SolarIconsData(0xed50, fontFamily: _fontFamily);
-  static const SolarIconsData flag =
-      SolarIconsData(0xed51, fontFamily: _fontFamily);
-  static const SolarIconsData fuel =
-      SolarIconsData(0xed52, fontFamily: _fontFamily);
-  static const SolarIconsData glasses =
-      SolarIconsData(0xed53, fontFamily: _fontFamily);
-  static const SolarIconsData hamburgerMenu =
-      SolarIconsData(0xed54, fontFamily: _fontFamily);
-  static const SolarIconsData help =
-      SolarIconsData(0xed55, fontFamily: _fontFamily);
-  static const SolarIconsData highDefinition =
-      SolarIconsData(0xed56, fontFamily: _fontFamily);
-  static const SolarIconsData highQuality =
-      SolarIconsData(0xed57, fontFamily: _fontFamily);
-  static const SolarIconsData paperBin =
-      SolarIconsData(0xed58, fontFamily: _fontFamily);
-  static const SolarIconsData paw =
-      SolarIconsData(0xed59, fontFamily: _fontFamily);
-  static const SolarIconsData power =
-      SolarIconsData(0xed5a, fontFamily: _fontFamily);
-  static const SolarIconsData reorder1 =
-      SolarIconsData(0xed5b, fontFamily: _fontFamily);
-  static const SolarIconsData scissors =
-      SolarIconsData(0xed5c, fontFamily: _fontFamily);
-  static const SolarIconsData sort =
-      SolarIconsData(0xed5d, fontFamily: _fontFamily);
-  static const SolarIconsData specialEffects =
-      SolarIconsData(0xed5e, fontFamily: _fontFamily);
-  static const SolarIconsData winRar =
-      SolarIconsData(0xed5f, fontFamily: _fontFamily);
-  static const SolarIconsData xxx =
-      SolarIconsData(0xed60, fontFamily: _fontFamily);
-  static const SolarIconsData broom =
-      SolarIconsData(0xed61, fontFamily: _fontFamily);
-  static const SolarIconsData cat =
-      SolarIconsData(0xed62, fontFamily: _fontFamily);
-  static const SolarIconsData copy =
-      SolarIconsData(0xed63, fontFamily: _fontFamily);
-  static const SolarIconsData crownLine =
-      SolarIconsData(0xed64, fontFamily: _fontFamily);
-  static const SolarIconsData crownMinimalistic =
-      SolarIconsData(0xed65, fontFamily: _fontFamily);
-  static const SolarIconsData crownStar =
-      SolarIconsData(0xed66, fontFamily: _fontFamily);
-  static const SolarIconsData crown =
-      SolarIconsData(0xed67, fontFamily: _fontFamily);
-  static const SolarIconsData database =
-      SolarIconsData(0xed68, fontFamily: _fontFamily);
-  static const SolarIconsData ghostSmile =
-      SolarIconsData(0xed69, fontFamily: _fontFamily);
-  static const SolarIconsData ghost =
-      SolarIconsData(0xed6a, fontFamily: _fontFamily);
-  static const SolarIconsData pinCircle =
-      SolarIconsData(0xed6b, fontFamily: _fontFamily);
-  static const SolarIconsData pinList =
-      SolarIconsData(0xed6d, fontFamily: _fontFamily);
-  static const SolarIconsData pin =
-      SolarIconsData(0xed6e, fontFamily: _fontFamily);
-  static const SolarIconsData plate =
-      SolarIconsData(0xed6f, fontFamily: _fontFamily);
-  static const SolarIconsData postsCarouselHorizontal =
-      SolarIconsData(0xed70, fontFamily: _fontFamily);
-  static const SolarIconsData postsCarouselVertical =
-      SolarIconsData(0xed71, fontFamily: _fontFamily);
-  static const SolarIconsData shareCircle =
-      SolarIconsData(0xed72, fontFamily: _fontFamily);
-  static const SolarIconsData share =
-      SolarIconsData(0xed73, fontFamily: _fontFamily);
-  static const SolarIconsData sliderMinimalisticHorizontal =
-      SolarIconsData(0xed74, fontFamily: _fontFamily);
-  static const SolarIconsData subtitles =
-      SolarIconsData(0xed75, fontFamily: _fontFamily);
-  static const SolarIconsData target =
-      SolarIconsData(0xed76, fontFamily: _fontFamily);
-  static const SolarIconsData trafficEconomy =
-      SolarIconsData(0xed77, fontFamily: _fontFamily);
-  static const SolarIconsData traffic =
-      SolarIconsData(0xed78, fontFamily: _fontFamily);
-  static const SolarIconsData trashBinMinimalistic_2 =
-      SolarIconsData(0xed79, fontFamily: _fontFamily);
-  static const SolarIconsData trashBinMinimalistic =
-      SolarIconsData(0xed7a, fontFamily: _fontFamily);
-  static const SolarIconsData umbrella =
-      SolarIconsData(0xed7b, fontFamily: _fontFamily);
-  static const SolarIconsData waterdrop =
-      SolarIconsData(0xed7c, fontFamily: _fontFamily);
-  static const SolarIconsData batteryChargeMinimalistic =
-      SolarIconsData(0xed7d, fontFamily: _fontFamily);
-  static const SolarIconsData batteryCharge =
-      SolarIconsData(0xed7e, fontFamily: _fontFamily);
-  static const SolarIconsData batteryFullMinimalistic =
-      SolarIconsData(0xed7f, fontFamily: _fontFamily);
-  static const SolarIconsData batteryFull =
-      SolarIconsData(0xed80, fontFamily: _fontFamily);
-  static const SolarIconsData batteryHalfMinimalistic =
-      SolarIconsData(0xed81, fontFamily: _fontFamily);
-  static const SolarIconsData batteryHalf =
-      SolarIconsData(0xed82, fontFamily: _fontFamily);
-  static const SolarIconsData batteryLowMinimalistic =
-      SolarIconsData(0xed83, fontFamily: _fontFamily);
-  static const SolarIconsData batteryLow =
-      SolarIconsData(0xed84, fontFamily: _fontFamily);
-  static const SolarIconsData home2 =
-      SolarIconsData(0xed85, fontFamily: _fontFamily);
-  static const SolarIconsData homeAddAngle =
-      SolarIconsData(0xed86, fontFamily: _fontFamily);
-  static const SolarIconsData homeAdd =
-      SolarIconsData(0xed87, fontFamily: _fontFamily);
-  static const SolarIconsData homeAngle_2 =
-      SolarIconsData(0xed88, fontFamily: _fontFamily);
-  static const SolarIconsData homeAngle =
-      SolarIconsData(0xed89, fontFamily: _fontFamily);
-  static const SolarIconsData homeSmileAngle =
-      SolarIconsData(0xed8a, fontFamily: _fontFamily);
-  static const SolarIconsData homeSmile =
-      SolarIconsData(0xed8b, fontFamily: _fontFamily);
-  static const SolarIconsData homeWiFiAngle =
-      SolarIconsData(0xed8c, fontFamily: _fontFamily);
-  static const SolarIconsData homeWiFi =
-      SolarIconsData(0xed8d, fontFamily: _fontFamily);
-  static const SolarIconsData home =
-      SolarIconsData(0xed8e, fontFamily: _fontFamily);
-  static const SolarIconsData infoSquare =
-      SolarIconsData(0xed8f, fontFamily: _fontFamily);
-  static const SolarIconsData menuDotsCircle =
-      SolarIconsData(0xed90, fontFamily: _fontFamily);
-  static const SolarIconsData menuDotsSquare =
-      SolarIconsData(0xed91, fontFamily: _fontFamily);
-  static const SolarIconsData menuDots =
-      SolarIconsData(0xed92, fontFamily: _fontFamily);
-  static const SolarIconsData minusSquare =
-      SolarIconsData(0xed93, fontFamily: _fontFamily);
-  static const SolarIconsData revote =
-      SolarIconsData(0xed94, fontFamily: _fontFamily);
-  static const SolarIconsData sliderHorizontal =
-      SolarIconsData(0xed95, fontFamily: _fontFamily);
-  static const SolarIconsData sliderVerticalMinimalistic =
-      SolarIconsData(0xed96, fontFamily: _fontFamily);
-  static const SolarIconsData sliderVertical =
-      SolarIconsData(0xed97, fontFamily: _fontFamily);
-  static const SolarIconsData smartHomeAngle =
-      SolarIconsData(0xed98, fontFamily: _fontFamily);
-  static const SolarIconsData smartHome =
-      SolarIconsData(0xed99, fontFamily: _fontFamily);
-  static const SolarIconsData addCircle =
-      SolarIconsData(0xed9a, fontFamily: _fontFamily);
-  static const SolarIconsData addSquare =
-      SolarIconsData(0xed9b, fontFamily: _fontFamily);
-  static const SolarIconsData checkCircle =
-      SolarIconsData(0xed9c, fontFamily: _fontFamily);
-  static const SolarIconsData checkSquare =
-      SolarIconsData(0xed9d, fontFamily: _fontFamily);
-  static const SolarIconsData closeCircle =
-      SolarIconsData(0xed9e, fontFamily: _fontFamily);
-  static const SolarIconsData closeSquare =
-      SolarIconsData(0xed9f, fontFamily: _fontFamily);
-  static const SolarIconsData dangerCircle =
-      SolarIconsData(0xeda0, fontFamily: _fontFamily);
-  static const SolarIconsData dangerSquare =
-      SolarIconsData(0xeda1, fontFamily: _fontFamily);
-  static const SolarIconsData dangerTriangle =
-      SolarIconsData(0xeda2, fontFamily: _fontFamily);
-  static const SolarIconsData danger =
-      SolarIconsData(0xeda3, fontFamily: _fontFamily);
-  static const SolarIconsData forbiddenCircle =
-      SolarIconsData(0xeda4, fontFamily: _fontFamily);
-  static const SolarIconsData forbidden =
-      SolarIconsData(0xeda5, fontFamily: _fontFamily);
-  static const SolarIconsData infoCircle =
-      SolarIconsData(0xeda6, fontFamily: _fontFamily);
-  static const SolarIconsData minusCircle =
-      SolarIconsData(0xeda7, fontFamily: _fontFamily);
-  static const SolarIconsData questionCircle =
-      SolarIconsData(0xeda8, fontFamily: _fontFamily);
-  static const SolarIconsData questionSquare =
-      SolarIconsData(0xeda9, fontFamily: _fontFamily);
-  static const SolarIconsData userHandUp =
-      SolarIconsData(0xedaa, fontFamily: _fontFamily);
-  static const SolarIconsData userHands =
-      SolarIconsData(0xedab, fontFamily: _fontFamily);
-  static const SolarIconsData userHeart =
-      SolarIconsData(0xedac, fontFamily: _fontFamily);
-  static const SolarIconsData userBlockRounded =
-      SolarIconsData(0xedad, fontFamily: _fontFamily);
-  static const SolarIconsData userBlock =
-      SolarIconsData(0xedae, fontFamily: _fontFamily);
-  static const SolarIconsData userCheckRounded =
-      SolarIconsData(0xedaf, fontFamily: _fontFamily);
-  static const SolarIconsData userCheck =
-      SolarIconsData(0xedb0, fontFamily: _fontFamily);
-  static const SolarIconsData userCircle =
-      SolarIconsData(0xedb1, fontFamily: _fontFamily);
-  static const SolarIconsData userCrossRounded =
-      SolarIconsData(0xedb2, fontFamily: _fontFamily);
-  static const SolarIconsData userCross =
-      SolarIconsData(0xedb3, fontFamily: _fontFamily);
-  static const SolarIconsData userHeartRounded =
-      SolarIconsData(0xedb4, fontFamily: _fontFamily);
-  static const SolarIconsData userId =
-      SolarIconsData(0xedb5, fontFamily: _fontFamily);
-  static const SolarIconsData userMinusRounded =
-      SolarIconsData(0xedb6, fontFamily: _fontFamily);
-  static const SolarIconsData userMinus =
-      SolarIconsData(0xedb7, fontFamily: _fontFamily);
-  static const SolarIconsData userPlusRounded =
-      SolarIconsData(0xedb8, fontFamily: _fontFamily);
-  static const SolarIconsData userPlus =
-      SolarIconsData(0xedb9, fontFamily: _fontFamily);
-  static const SolarIconsData userRounded =
-      SolarIconsData(0xedba, fontFamily: _fontFamily);
-  static const SolarIconsData userSpeakRounded =
-      SolarIconsData(0xedbb, fontFamily: _fontFamily);
-  static const SolarIconsData userSpeak =
-      SolarIconsData(0xedbc, fontFamily: _fontFamily);
-  static const SolarIconsData user =
-      SolarIconsData(0xedbd, fontFamily: _fontFamily);
-  static const SolarIconsData usersGroupRounded =
-      SolarIconsData(0xedbe, fontFamily: _fontFamily);
-  static const SolarIconsData usersGroupTwoRounded =
-      SolarIconsData(0xedbf, fontFamily: _fontFamily);
-  static const SolarIconsData handHeart =
-      SolarIconsData(0xedc0, fontFamily: _fontFamily);
-  static const SolarIconsData handMoney =
-      SolarIconsData(0xedc1, fontFamily: _fontFamily);
-  static const SolarIconsData handPills =
-      SolarIconsData(0xedc2, fontFamily: _fontFamily);
-  static const SolarIconsData handShake =
-      SolarIconsData(0xedc3, fontFamily: _fontFamily);
-  static const SolarIconsData handStars =
-      SolarIconsData(0xedc4, fontFamily: _fontFamily);
-  static const SolarIconsData buildings_2 =
-      SolarIconsData(0xedc5, fontFamily: _fontFamily);
-  static const SolarIconsData buildings_3 =
-      SolarIconsData(0xedc6, fontFamily: _fontFamily);
-  static const SolarIconsData buildings =
-      SolarIconsData(0xedc7, fontFamily: _fontFamily);
-  static const SolarIconsData city =
-      SolarIconsData(0xedc8, fontFamily: _fontFamily);
-  static const SolarIconsData garage =
-      SolarIconsData(0xedc9, fontFamily: _fontFamily);
-  static const SolarIconsData home1 =
-      SolarIconsData(0xedca, fontFamily: _fontFamily);
-  static const SolarIconsData hospital =
-      SolarIconsData(0xedcb, fontFamily: _fontFamily);
-  static const SolarIconsData kickScooter =
-      SolarIconsData(0xedcc, fontFamily: _fontFamily);
-  static const SolarIconsData scooter =
-      SolarIconsData(0xedcd, fontFamily: _fontFamily);
-  static const SolarIconsData speedometerLow =
-      SolarIconsData(0xedce, fontFamily: _fontFamily);
-  static const SolarIconsData speedometerMax =
-      SolarIconsData(0xedcf, fontFamily: _fontFamily);
-  static const SolarIconsData speedometerMiddle =
-      SolarIconsData(0xedd0, fontFamily: _fontFamily);
-  static const SolarIconsData wheelAngle =
-      SolarIconsData(0xedd1, fontFamily: _fontFamily);
-  static const SolarIconsData wheel =
-      SolarIconsData(0xedd2, fontFamily: _fontFamily);
-  static const SolarIconsData accumulator =
-      SolarIconsData(0xedd3, fontFamily: _fontFamily);
-  static const SolarIconsData bus =
-      SolarIconsData(0xedd4, fontFamily: _fontFamily);
-  static const SolarIconsData electricRefueling =
-      SolarIconsData(0xedd5, fontFamily: _fontFamily);
-  static const SolarIconsData gasStation =
-      SolarIconsData(0xedd6, fontFamily: _fontFamily);
-  static const SolarIconsData shockAbsorber =
-      SolarIconsData(0xedd7, fontFamily: _fontFamily);
-  static const SolarIconsData suspensionBolt =
-      SolarIconsData(0xedd8, fontFamily: _fontFamily);
-  static const SolarIconsData suspensionCross =
-      SolarIconsData(0xedd9, fontFamily: _fontFamily);
-  static const SolarIconsData suspension =
-      SolarIconsData(0xedda, fontFamily: _fontFamily);
-  static const SolarIconsData tram =
-      SolarIconsData(0xeddb, fontFamily: _fontFamily);
-  static const SolarIconsData transmissionCircle =
-      SolarIconsData(0xeddc, fontFamily: _fontFamily);
-  static const SolarIconsData transmissionSquare =
-      SolarIconsData(0xeddd, fontFamily: _fontFamily);
-  static const SolarIconsData transmission =
-      SolarIconsData(0xedde, fontFamily: _fontFamily);
+  static const forward = IconData(0xe900, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const inbox = IconData(0xe901, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const letterOpened = IconData(0xe902, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const letterUnread = IconData(0xe903, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const letter = IconData(0xe904, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mailbox = IconData(0xe905, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const multipleForwardLeft = IconData(0xe906, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const multipleForwardRight = IconData(0xe907, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const paperclip2 = IconData(0xe908, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const paperclipRounded2 = IconData(0xe909, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const paperclipRounded = IconData(0xe90a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const paperclip = IconData(0xe90b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const pen2 = IconData(0xe90c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const penNewRound = IconData(0xe90d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const penNewSquare = IconData(0xe90e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const pen = IconData(0xe90f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const plain2 = IconData(0xe910, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const plain3 = IconData(0xe911, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const plain = IconData(0xe912, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareForward = IconData(0xe913, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareShareLine = IconData(0xe914, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chatDots = IconData(0xe915, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chatLine = IconData(0xe916, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chatRoundCall = IconData(0xe917, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chatRoundCheck = IconData(0xe918, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chatRoundDots = IconData(0xe919, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chatRoundLike = IconData(0xe91a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chatRoundLine = IconData(0xe91b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chatRoundMoney = IconData(0xe91c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chatRoundUnread = IconData(0xe91d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chatRoundVideo = IconData(0xe91e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chatRound = IconData(0xe91f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chatSquareArrow = IconData(0xe920, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chatSquareCall = IconData(0xe921, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chatSquareCheck = IconData(0xe922, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chatSquareCode = IconData(0xe923, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chatSquareLike = IconData(0xe924, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chatSquare = IconData(0xe925, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chatUnread = IconData(0xe926, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chatRead = IconData(0xe927, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const dialog2 = IconData(0xe928, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const dialog = IconData(0xe929, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const inboxArchive = IconData(0xe92a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const inboxIn = IconData(0xe92b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const inboxLine = IconData(0xe92c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const inboxOut = IconData(0xe92d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const inboxUnread = IconData(0xe92e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const unread = IconData(0xe92f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const refreshCircle = IconData(0xe930, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const refreshSquare = IconData(0xe931, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const restartCircle = IconData(0xe932, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const restartSquare = IconData(0xe933, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const altArrowDown = IconData(0xe934, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const altArrowLeft = IconData(0xe935, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const altArrowRight = IconData(0xe936, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const altArrowUp = IconData(0xe937, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const arrowDown = IconData(0xe938, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const arrowLeftDown = IconData(0xe939, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const arrowLeftUp = IconData(0xe93a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const arrowLeft = IconData(0xe93b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const arrowRightDown = IconData(0xe93c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const arrowRightUp = IconData(0xe93d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const arrowRight = IconData(0xe93e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const arrowUp = IconData(0xe93f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const doubleAltArrowDown = IconData(0xe940, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const doubleAltArrowLeft = IconData(0xe941, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const doubleAltArrowRight = IconData(0xe942, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const doubleAltArrowUp = IconData(0xe943, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const refresh = IconData(0xe944, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const restart = IconData(0xe945, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundAltArrowDown = IconData(0xe946, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundAltArrowUp = IconData(0xe947, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundDoubleAltArrowLeft = IconData(0xe948, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundDoubleAltArrowRight = IconData(0xe949, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundDoubleAltArrowUp = IconData(0xe94a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundSortHorizontal = IconData(0xe94b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundTransferDiagonal = IconData(0xe94c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sortHorizontal = IconData(0xe94d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sortVertical = IconData(0xe94e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const transferHorizontal = IconData(0xe94f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const transferVertical = IconData(0xe950, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundAltArrowLeft = IconData(0xe951, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundAltArrowRight = IconData(0xe952, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundArrowDown = IconData(0xe953, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundArrowLeftDown = IconData(0xe954, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundArrowLeftUp = IconData(0xe955, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundArrowLeft = IconData(0xe956, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundArrowRightDown = IconData(0xe957, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundArrowRightUp = IconData(0xe958, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundArrowRight = IconData(0xe959, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundArrowUp = IconData(0xe95a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundDoubleAltArrowDown = IconData(0xe95b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundSortVertical = IconData(0xe95c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundTransferHorizontal = IconData(0xe95d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundTransferVertical = IconData(0xe95e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareAltArrowDown = IconData(0xe95f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareAltArrowUp = IconData(0xe960, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareArrowDown = IconData(0xe961, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareArrowLeftDown = IconData(0xe962, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareArrowLeftUp = IconData(0xe963, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareArrowLeft = IconData(0xe964, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareArrowRightDown = IconData(0xe965, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareArrowRightUp = IconData(0xe966, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareArrowRight = IconData(0xe967, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareArrowUp = IconData(0xe968, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareSortHorizontal = IconData(0xe969, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareSortVertical = IconData(0xe96a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareTransferHorizontal = IconData(0xe96b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareTransferVertical = IconData(0xe96c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareAltArrowLeft = IconData(0xe96d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareAltArrowRight = IconData(0xe96e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareDoubleAltArrowRight = IconData(0xe96f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareDoubleAltArrowDown = IconData(0xe970, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareDoubleAltArrowLeft = IconData(0xe971, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareDoubleAltArrowUp = IconData(0xe972, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const compassBig = IconData(0xe973, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const globus = IconData(0xe974, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const gps = IconData(0xe975, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const pointOnMapPerspective = IconData(0xe976, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const radar2 = IconData(0xe977, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const radar = IconData(0xe978, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const routing2 = IconData(0xe979, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const routing3 = IconData(0xe97a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const routing = IconData(0xe97b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const streetsMapPoint = IconData(0xe97c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const streetsNavigation = IconData(0xe97d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const streets = IconData(0xe97e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const branchingPathsDown = IconData(0xe97f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const branchingPathsUp = IconData(0xe980, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const compassSquare = IconData(0xe981, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const compass = IconData(0xe982, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const global = IconData(0xe983, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mapArrowDown = IconData(0xe984, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mapArrowLeft = IconData(0xe985, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mapArrowRight = IconData(0xe986, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mapArrowSquare = IconData(0xe987, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mapArrowUp = IconData(0xe988, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mapPointAdd = IconData(0xe989, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mapPointFavourite = IconData(0xe98a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mapPointHospital = IconData(0xe98b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mapPointRemove = IconData(0xe98c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mapPointRotate = IconData(0xe98d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mapPointSchool = IconData(0xe98e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mapPointSearch = IconData(0xe98f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mapPointWave = IconData(0xe990, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mapPoint = IconData(0xe991, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const map = IconData(0xe992, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const peopleNearby = IconData(0xe993, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const pointOnMap = IconData(0xe994, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const route = IconData(0xe995, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const signpost2 = IconData(0xe996, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const signpost = IconData(0xe997, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const fullScreenCircle = IconData(0xe998, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const fullScreenSquare = IconData(0xe999, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cameraAdd = IconData(0xe99a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cameraMinimalistic = IconData(0xe99b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cameraRotate = IconData(0xe99c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cameraSquare = IconData(0xe99d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const camera = IconData(0xe99e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const fullScreen = IconData(0xe99f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const galleryCircle = IconData(0xe9a0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const galleryFavourite = IconData(0xe9a1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const galleryRound = IconData(0xe9a2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const pauseCircle = IconData(0xe9a3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const pip2 = IconData(0xe9a4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const pip = IconData(0xe9a5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const playbackSpeed = IconData(0xe9a6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const quitFullScreenCircle = IconData(0xe9a7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const quitFullScreenSquare = IconData(0xe9a8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const quitFullScreen = IconData(0xe9a9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const quitPIP = IconData(0xe9aa, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const reel2 = IconData(0xe9ab, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const reel = IconData(0xe9ac, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const rewindBackCircle = IconData(0xe9ad, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const rewindForwardCircle = IconData(0xe9ae, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const shuffle = IconData(0xe9af, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const stopCircle = IconData(0xe9b0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const stream = IconData(0xe9b1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const toPIP = IconData(0xe9b2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const videocameraAdd = IconData(0xe9b3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const videocameraRecord = IconData(0xe9b4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const videocamera = IconData(0xe9b5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const clapperboardEdit = IconData(0xe9b6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const clapperboardText = IconData(0xe9b7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const galleryAdd = IconData(0xe9b8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const galleryCheck = IconData(0xe9b9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const galleryEdit = IconData(0xe9ba, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const galleryRemove = IconData(0xe9bb, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const gallerySend = IconData(0xe9bc, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const microphoneLarge = IconData(0xe9bd, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const musicLibrary2 = IconData(0xe9be, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const musicLibrary = IconData(0xe9bf, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const musicNoteSlider2 = IconData(0xe9c0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const musicNoteSlider = IconData(0xe9c1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const musicNotes = IconData(0xe9c2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const panorama = IconData(0xe9c3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const playCircle = IconData(0xe9c4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const podcast = IconData(0xe9c5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const rewind10SecondsBack = IconData(0xe9c6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const rewind10SecondsForward = IconData(0xe9c7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const rewindBack = IconData(0xe9c8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const rewindForward = IconData(0xe9c9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const skipNext = IconData(0xe9ca, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const skipPrevious = IconData(0xe9cb, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const uploadTrack2 = IconData(0xe9cc, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const uploadTrack = IconData(0xe9cd, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const videoFrame2 = IconData(0xe9ce, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const videoFramePlayHorizontal = IconData(0xe9cf, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const videoFramePlayVertical = IconData(0xe9d0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const volumeCross = IconData(0xe9d1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const wallpaper = IconData(0xe9d2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const album = IconData(0xe9d3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const clapperboardOpenPlay = IconData(0xe9d4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const clapperboardOpen = IconData(0xe9d5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const galleryDownload = IconData(0xe9d6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const galleryMinimalistic = IconData(0xe9d7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const galleryWide = IconData(0xe9d8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const microphone3 = IconData(0xe9d9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const microphone = IconData(0xe9da, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const musicNote2 = IconData(0xe9db, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const musicNote3 = IconData(0xe9dc, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const musicNote = IconData(0xe9dd, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const muted = IconData(0xe9de, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const pause = IconData(0xe9df, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const playStream = IconData(0xe9e0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const play = IconData(0xe9e1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const repeatOneMinimalistic = IconData(0xe9e2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const repeatOne = IconData(0xe9e3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const rewind15SecondsBack = IconData(0xe9e4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const rewind15SecondsForward = IconData(0xe9e5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const soundwaveCircle = IconData(0xe9e6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const soundwaveSquare = IconData(0xe9e7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const stop = IconData(0xe9e8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const videoFrameCut2 = IconData(0xe9e9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const videoFrameReplace = IconData(0xe9ea, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const videoLibrary = IconData(0xe9eb, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const vinylRecord = IconData(0xe9ec, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const vinyl = IconData(0xe9ed, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const volume = IconData(0xe9ee, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const clapperboardPlay = IconData(0xe9ef, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const clapperboard = IconData(0xe9f0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const gallery = IconData(0xe9f1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const library = IconData(0xe9f2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const microphone2 = IconData(0xe9f3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const musicNote4 = IconData(0xe9f4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const recordCircle = IconData(0xe9f5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const record = IconData(0xe9f6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const repeat = IconData(0xe9f7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const rewind5SecondsBack = IconData(0xe9f8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const rewind5SecondsForward = IconData(0xe9f9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const soundwave = IconData(0xe9fa, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const videoFrameCut = IconData(0xe9fb, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const videoFrame = IconData(0xe9fc, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const volumeLoud = IconData(0xe9fd, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const volumeSmall = IconData(0xe9fe, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const billCheck = IconData(0xe9ff, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const billCross = IconData(0xea00, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const billList = IconData(0xea01, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bill = IconData(0xea02, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cashOut = IconData(0xea03, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const dollarMinimalistic = IconData(0xea04, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const moneyBag = IconData(0xea05, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const safe2 = IconData(0xea06, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const banknote2 = IconData(0xea07, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const banknote = IconData(0xea08, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const card2 = IconData(0xea09, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cardReceive = IconData(0xea0a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cardSearch = IconData(0xea0b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cardSend = IconData(0xea0c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cardTransfer = IconData(0xea0d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const card = IconData(0xea0e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cardholder = IconData(0xea0f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const dollar = IconData(0xea10, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const euro = IconData(0xea11, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const ruble = IconData(0xea12, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const safeCircle = IconData(0xea13, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const safeSquare = IconData(0xea14, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const saleSquare = IconData(0xea15, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sale = IconData(0xea16, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const tagHorizontal = IconData(0xea17, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const tagPrice = IconData(0xea18, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const tag = IconData(0xea19, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const tickerStar = IconData(0xea1a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const ticketSale = IconData(0xea1b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const ticket = IconData(0xea1c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const verifiedCheck = IconData(0xea1d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const wadOfMoney = IconData(0xea1e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const wallet2 = IconData(0xea1f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const walletMoney = IconData(0xea20, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const wallet = IconData(0xea21, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cloudStorage = IconData(0xea22, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const devices = IconData(0xea23, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const flashDrive = IconData(0xea24, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const lightbulbBold = IconData(0xea25, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const lightbulbMinimalistic = IconData(0xea26, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const lightbulb = IconData(0xea27, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const lightning = IconData(0xea28, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const socket = IconData(0xea29, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const ssdRound = IconData(0xea2a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const ssdSquare = IconData(0xea2b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const weigher = IconData(0xea2c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bluetoothCircle = IconData(0xea2d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bluetoothSquare = IconData(0xea2e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bluetoothWave = IconData(0xea2f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bluetooth = IconData(0xea30, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const diskette = IconData(0xea31, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const display = IconData(0xea32, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const gameboy = IconData(0xea33, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const keyboard = IconData(0xea34, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const monitorCamera = IconData(0xea35, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const monitorSmartphone = IconData(0xea36, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const monitor = IconData(0xea37, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const plugCircle = IconData(0xea38, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const printer2 = IconData(0xea39, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const printerMinimalistic = IconData(0xea3a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const printer = IconData(0xea3b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const projector = IconData(0xea3c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const radioMinimalistic = IconData(0xea3d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const radio = IconData(0xea3e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sdCard = IconData(0xea3f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const simCardMinimalistic = IconData(0xea40, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const simCard = IconData(0xea41, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const simCards = IconData(0xea42, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const smartSpeaker2 = IconData(0xea43, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const smartSpeakerMinimalistic = IconData(0xea44, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const smartSpeaker = IconData(0xea45, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const telescope = IconData(0xea46, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const tv = IconData(0xea47, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const wirelessCharge = IconData(0xea48, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const airbudsCaseCharge = IconData(0xea49, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const airbudsCaseMinimalistic = IconData(0xea4a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const airbudsCaseOpen = IconData(0xea4b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const airbudsCase = IconData(0xea4c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const airbudsCharge = IconData(0xea4d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const airbudsCheck = IconData(0xea4e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const airbudsLeft = IconData(0xea4f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const airbudsRemove = IconData(0xea50, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const airbudsRight = IconData(0xea51, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const airbuds = IconData(0xea52, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const boombox = IconData(0xea53, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cassette2 = IconData(0xea54, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cassette = IconData(0xea55, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cpuBolt = IconData(0xea56, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cpu = IconData(0xea57, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const laptop2 = IconData(0xea58, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const laptop3 = IconData(0xea59, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const laptopMinimalistic = IconData(0xea5a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const laptop = IconData(0xea5b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mouseCircle = IconData(0xea5c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mouseMinimalistic = IconData(0xea5d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mouse = IconData(0xea5e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const serverMinimalistic = IconData(0xea5f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const serverPath = IconData(0xea60, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const serverSquareCloud = IconData(0xea61, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const serverSquareUpdate = IconData(0xea62, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const turntableMinimalistic = IconData(0xea63, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const turntableMusicNote = IconData(0xea64, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const turntable = IconData(0xea65, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const gamepadCharge = IconData(0xea66, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const gamepadMinimalistic = IconData(0xea67, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const gamepadNoCharge = IconData(0xea68, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const gamepadOld = IconData(0xea69, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const gamepad = IconData(0xea6a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const headphonesRoundSound = IconData(0xea6b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const headphonesRound = IconData(0xea6c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const headphonesSquareSound = IconData(0xea6d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const headphonesSquare = IconData(0xea6e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const iPhone = IconData(0xea6f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const server2 = IconData(0xea70, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const serverSquare = IconData(0xea71, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const server = IconData(0xea72, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const smartphone2 = IconData(0xea73, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const smartphoneRotate2 = IconData(0xea74, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const smartphoneRotateAngle = IconData(0xea75, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const smartphoneRotateOrientation = IconData(0xea76, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const smartphoneUpdate = IconData(0xea77, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const smartphoneVibration = IconData(0xea78, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const smartphone = IconData(0xea79, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const tablet = IconData(0xea7a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cloudDownload = IconData(0xea7b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cloudUpload = IconData(0xea7c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cloudyMoon = IconData(0xea7d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const moonFog = IconData(0xea7e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const moonSleep = IconData(0xea7f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const moonStars = IconData(0xea80, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const moon = IconData(0xea81, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const snowflake = IconData(0xea82, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const stars = IconData(0xea83, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sun2 = IconData(0xea84, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sunfog = IconData(0xea85, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sun = IconData(0xea86, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sunrise = IconData(0xea87, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sunset = IconData(0xea88, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const temperature = IconData(0xea89, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const tornadoSmall = IconData(0xea8a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const waterdrops = IconData(0xea8b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const wind = IconData(0xea8c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cloudBoltMinimalistic = IconData(0xea8d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cloudBolt = IconData(0xea8e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cloudCheck = IconData(0xea8f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cloudMinus = IconData(0xea90, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cloudPlus = IconData(0xea91, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cloudRain = IconData(0xea92, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cloudSnowfallMinimalistic = IconData(0xea93, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cloudSnowfall = IconData(0xea94, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cloudStorm = IconData(0xea95, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cloudSun2 = IconData(0xea96, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cloudSun = IconData(0xea97, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cloudWaterdrop = IconData(0xea98, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cloudWaterdrops = IconData(0xea99, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cloud = IconData(0xea9a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const clouds = IconData(0xea9b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cloudCross = IconData(0xea9c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const fog = IconData(0xea9d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const tornado = IconData(0xea9e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const fileCorrupted = IconData(0xea9f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const fileSmile = IconData(0xeaa0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const zipFile = IconData(0xeaa1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const codeFile = IconData(0xeaa2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const figmaFile = IconData(0xeaa3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const fileCheck = IconData(0xeaa4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const fileDownload = IconData(0xeaa5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const fileFavourite = IconData(0xeaa6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const fileLeft = IconData(0xeaa7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const fileRemove = IconData(0xeaa8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const fileRight = IconData(0xeaa9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const fileSend = IconData(0xeaaa, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const fileText = IconData(0xeaab, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const file = IconData(0xeaac, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cloudFile = IconData(0xeaad, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const folder2 = IconData(0xeaae, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const folderCheck = IconData(0xeaaf, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const folderCloud = IconData(0xeab0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const folderError = IconData(0xeab1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const folderFavouriteBookmark = IconData(0xeab2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const folderFavouriteStar = IconData(0xeab3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const folderOpen = IconData(0xeab4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const folderPathConnect = IconData(0xeab5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const folderSecurity = IconData(0xeab6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const folderWithFiles = IconData(0xeab7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const folder = IconData(0xeab8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const moveToFolder = IconData(0xeab9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const removeFolder = IconData(0xeaba, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const addFolder = IconData(0xeabb, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const starFall2 = IconData(0xeabc, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const starFallMinimalistic2 = IconData(0xeabd, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const starFallMinimalistic = IconData(0xeabe, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const starRing = IconData(0xeabf, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const starRings = IconData(0xeac0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const star = IconData(0xeac1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const starsLine = IconData(0xeac2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const starsMinimalistic = IconData(0xeac3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const stars1 = IconData(0xeac4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const asteroid = IconData(0xeac5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const atom = IconData(0xeac6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const blackHole2 = IconData(0xeac7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const blackHole3 = IconData(0xeac8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const blackHole = IconData(0xeac9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const earth = IconData(0xeaca, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const infinity = IconData(0xeacb, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const men = IconData(0xeacc, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const planet2 = IconData(0xeacd, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const planet3 = IconData(0xeace, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const planet4 = IconData(0xeacf, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const planet = IconData(0xead0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const rocket2 = IconData(0xead1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const rocket = IconData(0xead2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const satellite = IconData(0xead3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const starAngle = IconData(0xead4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const starCircle = IconData(0xead5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const starFall = IconData(0xead6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const starRainbow = IconData(0xead7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const ufo2 = IconData(0xead8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const ufo3 = IconData(0xead9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const ufo = IconData(0xeada, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const women = IconData(0xeadb, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const confoundedCircle = IconData(0xeadc, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const confoundedSquare = IconData(0xeadd, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const emojiFunnyCircle = IconData(0xeade, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const emojiFunnySquare = IconData(0xeadf, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const faceScanCircle = IconData(0xeae0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const faceScanSquare = IconData(0xeae1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const facemaskCircle = IconData(0xeae2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const facemaskSquare = IconData(0xeae3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sadCircle = IconData(0xeae4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sadSquare = IconData(0xeae5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sleepingCircle = IconData(0xeae6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sleepingSquare = IconData(0xeae7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const stickerCircle = IconData(0xeae8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const stickerSmileCircle2 = IconData(0xeae9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const stickerSmileCircle = IconData(0xeaea, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const stickerSmileSquare = IconData(0xeaeb, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const stickerSquare = IconData(0xeaec, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const expressionlessCircle = IconData(0xeaed, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const expressionlessSquare = IconData(0xeaee, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const smileCircle = IconData(0xeaef, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const smileSquare = IconData(0xeaf0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const balls = IconData(0xeaf1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const basketball = IconData(0xeaf2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bodyShapeMinimalistic = IconData(0xeaf3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bodyShape = IconData(0xeaf4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bowling = IconData(0xeaf5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const dumbbellLargeMinimalistic = IconData(0xeaf6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const dumbbellLarge = IconData(0xeaf7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const dumbbellSmall = IconData(0xeaf8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const dumbbell = IconData(0xeaf9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const dumbbells2 = IconData(0xeafa, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const dumbbells = IconData(0xeafb, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const football = IconData(0xeafc, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const golf = IconData(0xeafd, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const meditationRound = IconData(0xeafe, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const meditation = IconData(0xeaff, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const ranking = IconData(0xeb00, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const rugby = IconData(0xeb01, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const runningRound = IconData(0xeb02, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const stretchingRound = IconData(0xeb03, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const stretching = IconData(0xeb04, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const swimming = IconData(0xeb05, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const tennis2 = IconData(0xeb06, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const tennis = IconData(0xeb07, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const treadmillRound = IconData(0xeb08, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const treadmill = IconData(0xeb09, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const volleyball2 = IconData(0xeb0a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const volleyball = IconData(0xeb0b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const waterSun = IconData(0xeb0c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const water = IconData(0xeb0d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bicyclingRound = IconData(0xeb0e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bicycling = IconData(0xeb0f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const hikingMinimalistic = IconData(0xeb10, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const hikingRound = IconData(0xeb11, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const hiking = IconData(0xeb12, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const running_2 = IconData(0xeb13, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const running = IconData(0xeb14, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const skateboard = IconData(0xeb15, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const skateboardingRound = IconData(0xeb16, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const skateboarding = IconData(0xeb17, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const walkingRound = IconData(0xeb18, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const walking = IconData(0xeb19, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const magnifierBug = IconData(0xeb1a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const magnifierZoomIn = IconData(0xeb1b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const magnifierZoomOut = IconData(0xeb1c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const magnifier = IconData(0xeb1d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const minimalisticMagnifierBug = IconData(0xeb1e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const minimalisticMagnifierZoomIn = IconData(0xeb1f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const minimalisticMagnifierZoomOut = IconData(0xeb20, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const minimalisticMagnifier = IconData(0xeb21, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundedMagnifierBug = IconData(0xeb22, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundedMagnifierZoomIn = IconData(0xeb23, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundedMagnifierZoomOut = IconData(0xeb24, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundedMagnifier = IconData(0xeb25, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const calendarAdd = IconData(0xeb26, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const calendarDate = IconData(0xeb27, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const calendarMark = IconData(0xeb28, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const calendarMinimalistic = IconData(0xeb29, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const calendarSearch = IconData(0xeb2a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const calendar = IconData(0xeb2b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const hourglassLine = IconData(0xeb2c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const watchRound = IconData(0xeb2d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const watchSquareMinimalisticCharge = IconData(0xeb2e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const watchSquareMinimalistic = IconData(0xeb2f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const watchSquare = IconData(0xeb30, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const alarmAdd = IconData(0xeb31, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const alarmPause = IconData(0xeb32, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const alarmPlay = IconData(0xeb33, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const alarmRemove = IconData(0xeb34, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const alarmSleep = IconData(0xeb35, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const alarmTurnOff = IconData(0xeb36, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const alarm = IconData(0xeb37, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const clockCircle = IconData(0xeb38, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const clockSquare = IconData(0xeb39, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const history_2 = IconData(0xeb3a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const history3 = IconData(0xeb3b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const history = IconData(0xeb3c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const hourglass = IconData(0xeb3d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const stopwatchPause = IconData(0xeb3e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const stopwatchPlay = IconData(0xeb3f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const stopwatch = IconData(0xeb40, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sortFromTopToBottom = IconData(0xeb41, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sortFromBottomToTop = IconData(0xeb42, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sortByTime = IconData(0xeb43, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sortByAlphabet = IconData(0xeb44, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const playlist = IconData(0xeb45, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const playlistMinimalistic3 = IconData(0xeb46, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const playlistMinimalistic2 = IconData(0xeb47, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const playlist_2 = IconData(0xeb48, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const playlistMinimalistic = IconData(0xeb49, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const list_1 = IconData(0xeb4a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const list = IconData(0xeb4b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const listUp = IconData(0xeb4c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const listUpMinimalistic = IconData(0xeb4d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const listHeart = IconData(0xeb4e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const listHeartMinimalistic = IconData(0xeb4f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const listDown = IconData(0xeb50, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const listDownMinimalistic = IconData(0xeb51, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const listCross = IconData(0xeb52, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const listCrossMinimalistic = IconData(0xeb53, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const listCheck = IconData(0xeb54, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const listCheckMinimalistic = IconData(0xeb55, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const listArrowUp = IconData(0xeb56, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const listArrowUpMinimalistic = IconData(0xeb57, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const listArrowDown = IconData(0xeb58, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const listArrowDownMinimalistic = IconData(0xeb59, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const checklist = IconData(0xeb5a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const checklistMinimalistic = IconData(0xeb5b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bill1 = IconData(0xeb5c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const callMedicine = IconData(0xeb5d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const recordCircle1 = IconData(0xeb5e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const recordMinimalistic = IconData(0xeb5f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const recordSquare = IconData(0xeb60, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const callCancelRounded = IconData(0xeb61, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const callCancel = IconData(0xeb62, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const callChatRounded = IconData(0xeb63, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const callChat = IconData(0xeb64, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const callDroppedRounded = IconData(0xeb65, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const callDropped = IconData(0xeb66, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const callMedicineRounded = IconData(0xeb67, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const endCallRounded = IconData(0xeb68, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const endCall = IconData(0xeb69, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const incomingCallRounded = IconData(0xeb6a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const incomingCall = IconData(0xeb6b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const outgoingCallRounded = IconData(0xeb6c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const outgoingCall = IconData(0xeb6d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const phoneCallingRounded = IconData(0xeb6e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const phoneCalling = IconData(0xeb6f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const phoneRounded = IconData(0xeb70, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const phone = IconData(0xeb71, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const health = IconData(0xeb72, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const heartPulse2 = IconData(0xeb73, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const heartPulse = IconData(0xeb74, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const medicalKit = IconData(0xeb75, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const pulse_2 = IconData(0xeb76, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const pulse = IconData(0xeb77, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const testTubeMinimalistic = IconData(0xeb78, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const testTube = IconData(0xeb79, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const virus = IconData(0xeb7a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const adhesivePlaster2 = IconData(0xeb7b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const adhesivePlaster = IconData(0xeb7c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bacteria = IconData(0xeb7d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const benzeneRing = IconData(0xeb7e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const boneBroken = IconData(0xeb7f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const boneCrack = IconData(0xeb80, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bone = IconData(0xeb81, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bones = IconData(0xeb82, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const dna = IconData(0xeb83, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const dropper_2 = IconData(0xeb84, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const dropper_3 = IconData(0xeb85, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const dropperMinimalistic2 = IconData(0xeb86, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const dropperMinimalistic = IconData(0xeb87, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const dropper = IconData(0xeb88, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const jarOfPills2 = IconData(0xeb89, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const jarOfPills = IconData(0xeb8a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const pill = IconData(0xeb8b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const pills_2 = IconData(0xeb8c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const pills_3 = IconData(0xeb8d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const pills = IconData(0xeb8e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const stethoscope = IconData(0xeb8f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const syringe = IconData(0xeb90, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const thermometer = IconData(0xeb91, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const armchair_2 = IconData(0xeb92, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const armchair = IconData(0xeb93, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const barChair = IconData(0xeb94, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bed = IconData(0xeb95, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bedsideTable2 = IconData(0xeb96, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bedsideTable3 = IconData(0xeb97, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bedsideTable = IconData(0xeb98, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chair_2 = IconData(0xeb99, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chair = IconData(0xeb9a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const closet_2 = IconData(0xeb9b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const floorLampMinimalistic = IconData(0xeb9c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const floorLamp = IconData(0xeb9d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const fridge = IconData(0xeb9e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const lamp = IconData(0xeb9f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const smartVacuumCleaner_2 = IconData(0xeba0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const smartVacuumCleaner = IconData(0xeba1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const volumeKnob = IconData(0xeba2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bath = IconData(0xeba3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bedsideTable4 = IconData(0xeba4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chandelier = IconData(0xeba5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const closet = IconData(0xeba6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const conditioner_2 = IconData(0xeba7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const conditioner = IconData(0xeba8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mirror = IconData(0xeba9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const remoteController2 = IconData(0xebaa, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const remoteControllerMinimalistic = IconData(0xebab, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const remoteController = IconData(0xebac, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sofa_2 = IconData(0xebad, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sofa_3 = IconData(0xebae, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sofa = IconData(0xebaf, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const speakerMinimalistic = IconData(0xebb0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const speaker = IconData(0xebb1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const trellis = IconData(0xebb2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const washingMachineMinimalistic = IconData(0xebb3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const washingMachine = IconData(0xebb4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bugMinimalistic = IconData(0xebb5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bug = IconData(0xebb6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const code2 = IconData(0xebb7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const codeCircle = IconData(0xebb8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const codeSquare = IconData(0xebb9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const code = IconData(0xebba, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const command = IconData(0xebbb, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const hashtagChat = IconData(0xebbc, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const hashtagCircle = IconData(0xebbd, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const hashtagSquare = IconData(0xebbe, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const hashtag = IconData(0xebbf, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const programming = IconData(0xebc0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const screencast_2 = IconData(0xebc1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const screencast = IconData(0xebc2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const slashCircle = IconData(0xebc3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const slashSquare = IconData(0xebc4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const stationMinimalistic = IconData(0xebc5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const station = IconData(0xebc6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const structure = IconData(0xebc7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const translation = IconData(0xebc8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sidebarCode = IconData(0xebc9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sidebarMinimalistic = IconData(0xebca, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sidebar = IconData(0xebcb, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const translation_2 = IconData(0xebcc, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const usbCircle = IconData(0xebcd, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const usbSquare = IconData(0xebce, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const usb = IconData(0xebcf, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const wifiRouterMinimalistic = IconData(0xebd0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const wifiRouterRound = IconData(0xebd1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const wifiRouter = IconData(0xebd2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const windowFrame = IconData(0xebd3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const tuning_2 = IconData(0xebd4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const tuning_3 = IconData(0xebd5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const tuning_4 = IconData(0xebd6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const tuningSquare_2 = IconData(0xebd7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const tuningSquare = IconData(0xebd8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const tuning = IconData(0xebd9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const widget_6 = IconData(0xebda, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const widgetAdd = IconData(0xebdb, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const settingsMinimalistic = IconData(0xebdc, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const settings = IconData(0xebdd, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const widget_2 = IconData(0xebde, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const widget_3 = IconData(0xebdf, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const widget_4 = IconData(0xebe0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const widget_5 = IconData(0xebe1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const widget = IconData(0xebe2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const backspace = IconData(0xebe3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const linkBrokenMinimalistic = IconData(0xebe4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const linkBroken = IconData(0xebe5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const linkCircle = IconData(0xebe6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const linkMinimalistic_2 = IconData(0xebe7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const linkMinimalistic = IconData(0xebe8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const linkRoundAngle = IconData(0xebe9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const linkRound = IconData(0xebea, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const linkSquare = IconData(0xebeb, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const link = IconData(0xebec, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const paragraphSpacing = IconData(0xebed, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const textBoldSquare = IconData(0xebee, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const textFieldFocus = IconData(0xebef, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const textField = IconData(0xebf0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const textSelection = IconData(0xebf1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const textSquare2 = IconData(0xebf2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const eraserCircle = IconData(0xebf3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const eraserSquare = IconData(0xebf4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const eraser = IconData(0xebf5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const textBoldCircle = IconData(0xebf6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const textBold = IconData(0xebf7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const textCircle = IconData(0xebf8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const textCrossCircle = IconData(0xebf9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const textCrossSquare = IconData(0xebfa, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const textCross = IconData(0xebfb, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const textItalicCircle = IconData(0xebfc, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const textItalicSquare = IconData(0xebfd, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const textItalic = IconData(0xebfe, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const textSquare = IconData(0xebff, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const textUnderlineCircle = IconData(0xec00, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const textUnderlineCross = IconData(0xec01, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const textUnderline = IconData(0xec02, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const text = IconData(0xec03, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chart_2 = IconData(0xec04, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chartSquare = IconData(0xec05, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chart = IconData(0xec06, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chatSquare_2 = IconData(0xec07, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const courseDown = IconData(0xec08, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const courseUp = IconData(0xec09, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const diagramDown = IconData(0xec0a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const diagramUp = IconData(0xec0b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const graphDownNew = IconData(0xec0c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const graphDown = IconData(0xec0d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const graphNewUp = IconData(0xec0e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const graphNew = IconData(0xec0f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const graphUp = IconData(0xec10, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const graph = IconData(0xec11, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const pieChart2 = IconData(0xec12, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const pieChart3 = IconData(0xec13, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const pieChart = IconData(0xec14, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const presentationGraph = IconData(0xec15, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const roundGraph = IconData(0xec16, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bag5 = IconData(0xec17, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bagHeart = IconData(0xec18, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bagMusic_2 = IconData(0xec19, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bagSmile = IconData(0xec1a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const shop_2 = IconData(0xec1b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const shopMinimalistic = IconData(0xec1c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const shop = IconData(0xec1d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bag2 = IconData(0xec1e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bag3 = IconData(0xec1f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bag4 = IconData(0xec20, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bagCheck = IconData(0xec21, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bagCross = IconData(0xec22, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bagMusic = IconData(0xec23, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bag = IconData(0xec24, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cart_2 = IconData(0xec25, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cart_3 = IconData(0xec26, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cart_4 = IconData(0xec27, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cart_5 = IconData(0xec28, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cartCheck = IconData(0xec29, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cartCross = IconData(0xec2a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cartLarge2 = IconData(0xec2b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cartLarge3 = IconData(0xec2c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cartLarge_4 = IconData(0xec2d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cartLargeMinimalistic = IconData(0xec2e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cartLarge = IconData(0xec2f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cartPlus = IconData(0xec30, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cart = IconData(0xec31, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bonfire = IconData(0xec32, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const fireMinimalistic = IconData(0xec33, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const fireSquare = IconData(0xec34, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const fire = IconData(0xec35, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const flame = IconData(0xec36, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const leaf = IconData(0xec37, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const suitcaseLines = IconData(0xec38, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const suitcaseTag = IconData(0xec39, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const suitcase = IconData(0xec3a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const backpack = IconData(0xec3b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const book2 = IconData(0xec3c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bookBookmarkMinimalistic = IconData(0xec3d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bookBookmark = IconData(0xec3e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bookMinimalistic = IconData(0xec3f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bookmarkCircle = IconData(0xec40, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bookmarkOpened = IconData(0xec41, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bookmarkSquareMinimalistic = IconData(0xec42, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bookmarkSquare = IconData(0xec43, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bookmark = IconData(0xec44, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const calculatorMinimalistic = IconData(0xec45, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const calculator = IconData(0xec46, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const document = IconData(0xec47, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const passportMinimalistic = IconData(0xec48, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const passport = IconData(0xec49, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const plus = IconData(0xec4a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const minus = IconData(0xec4a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const book = IconData(0xec4b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const caseMinimalistic = IconData(0xec4c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const caseRoundMinimalistic = IconData(0xec4d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const caseRound = IconData(0xec4e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const case_ = IconData(0xec4f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const diplomaVerified = IconData(0xec50, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const diploma = IconData(0xec51, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const notebookBookmark = IconData(0xec52, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const notebookMinimalistic = IconData(0xec53, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const notebookSquare = IconData(0xec54, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const notebook = IconData(0xec55, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareAcademicCap2 = IconData(0xec56, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareAcademicCap = IconData(0xec57, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const alignBottom = IconData(0xec58, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const alignHorizontalSpacing = IconData(0xec59, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const alignHorizontalCenter = IconData(0xec5a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const alignLeft = IconData(0xec5b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const alignRight = IconData(0xec5c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const alignTop = IconData(0xec5d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const alignVerticalCenter = IconData(0xec5e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const alignVerticalSpacing = IconData(0xec5f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cropMinimalistic = IconData(0xec60, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const crop = IconData(0xec61, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const layersMinimalistic = IconData(0xec62, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const layers = IconData(0xec63, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const paintRoller = IconData(0xec64, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const paletteRound = IconData(0xec65, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const palette = IconData(0xec66, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const palette2 = IconData(0xec67, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const colourTuning = IconData(0xec68, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const filters = IconData(0xec69, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const flipHorizontal = IconData(0xec6a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const flipVertical = IconData(0xec6b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mirrorLeft = IconData(0xec6c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mirrorRight = IconData(0xec6d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const pipette = IconData(0xec6e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const radialBlur = IconData(0xec6f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const rulerAngular = IconData(0xec70, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const rulerCrossPen = IconData(0xec71, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const rulerPen = IconData(0xec72, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const ruler = IconData(0xec73, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const threeSquares = IconData(0xec74, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const dislike = IconData(0xec75, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const heartAngle = IconData(0xec76, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const heartBroken = IconData(0xec77, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const heartLock = IconData(0xec78, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const heartShine = IconData(0xec79, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const heartUnlock = IconData(0xec7a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const heart = IconData(0xec7b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const hearts = IconData(0xec7c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const like = IconData(0xec7d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const medalRibbonStar = IconData(0xec7e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const medalRibbon = IconData(0xec7f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const medalRibbonsStart = IconData(0xec80, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const medalStarCircle = IconData(0xec81, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const medalStarSquare = IconData(0xec82, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const medalStar = IconData(0xec83, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const startShine = IconData(0xec84, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const start1 = IconData(0xec85, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const corkscrew = IconData(0xec86, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const ladle = IconData(0xec87, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const ovenMittsMinimalistic = IconData(0xec88, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const ovenMitts = IconData(0xec89, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const rollingPin = IconData(0xec8a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const whisk = IconData(0xec8b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bottle = IconData(0xec8c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chefHatHeart = IconData(0xec8d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chefHatMinimalistic = IconData(0xec8e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const chefHat = IconData(0xec8f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cupHot = IconData(0xec90, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cupPaper = IconData(0xec91, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cup = IconData(0xec92, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const donutBitten = IconData(0xec93, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const donut = IconData(0xec94, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const teaCup = IconData(0xec95, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const wineglassTriangle = IconData(0xec96, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const wineglass = IconData(0xec97, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const arrowToDownLeft = IconData(0xec98, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const arrowToDownRight = IconData(0xec99, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const arrowToTopLeft = IconData(0xec9a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const arrowToTopRight = IconData(0xec9b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const downloadMinimalistic = IconData(0xec9c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const download = IconData(0xec9d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const exit = IconData(0xec9e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const export = IconData(0xec9f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const forward_2 = IconData(0xeca0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const forward1 = IconData(0xeca1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const import = IconData(0xeca2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const login_2 = IconData(0xeca3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const login_3 = IconData(0xeca4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const login = IconData(0xeca5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const logout_2 = IconData(0xeca6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const logout_3 = IconData(0xeca7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const logout = IconData(0xeca8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const maximizeSquare2 = IconData(0xeca9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const minimizeSquare2 = IconData(0xecaa, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const minimizeSquareMinimalistic = IconData(0xecab, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const reply_2 = IconData(0xecac, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const reply = IconData(0xecad, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const screenShare = IconData(0xecae, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const uploadMinimalistic = IconData(0xecaf, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const upload = IconData(0xecb0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const circleBottomDown = IconData(0xecb1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const circleBottomUp = IconData(0xecb2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const circleTopDown = IconData(0xecb3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const circleTopUp = IconData(0xecb4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const downloadSquare = IconData(0xecb5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const maximizeSquare3 = IconData(0xecb6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const maximizeSquareMinimalistic = IconData(0xecb7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const maximizeSquare = IconData(0xecb8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const maximize = IconData(0xecb9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const minimizeSquare3 = IconData(0xecba, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const minimizeSquare = IconData(0xecbb, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const minimize = IconData(0xecbc, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const receiveSquare = IconData(0xecbd, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const reorder = IconData(0xecbe, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const scale = IconData(0xecbf, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareBottomDown = IconData(0xecc0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareBottomUp = IconData(0xecc1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareTopDown = IconData(0xecc2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const squareTopUp = IconData(0xecc3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const undoLeftRoundSquare = IconData(0xecc4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const undoLeftRound = IconData(0xecc5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const undoLeftSquare = IconData(0xecc6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const undoLeft = IconData(0xecc7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const undoRightRoundSquare = IconData(0xecc8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const undoRightRound = IconData(0xecc9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const undoRightSquare = IconData(0xecca, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const undoRight = IconData(0xeccb, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const uploadSquare = IconData(0xeccc, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const downloadTwiceSquare = IconData(0xeccd, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const receiveTwiceSquare = IconData(0xecce, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sendSquare = IconData(0xeccf, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sendTwiceSquare = IconData(0xecd0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const uploadTwiceSquare = IconData(0xecd1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bellBing = IconData(0xecd2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bellOff = IconData(0xecd3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bell = IconData(0xecd4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const notificationLinesRemove = IconData(0xecd5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const notificationRemove = IconData(0xecd6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const notificationUnreadLines = IconData(0xecd7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const notificationUnread = IconData(0xecd8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const archiveCheck = IconData(0xecd9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const archiveDownMinimalistic = IconData(0xecda, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const archiveDown = IconData(0xecdb, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const archiveMinimalistic = IconData(0xecdc, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const archiveUpMinimalistic = IconData(0xecdd, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const archiveUp = IconData(0xecde, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const archive = IconData(0xecdf, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const clipboardAdd = IconData(0xece0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const clipboardCheck = IconData(0xece1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const clipboardHeart = IconData(0xece2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const clipboardList = IconData(0xece3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const clipboardRemove = IconData(0xece4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const clipboardText = IconData(0xece5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const clipboard = IconData(0xece6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const documentsMinimalistic = IconData(0xece7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const notebook1 = IconData(0xece8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const notesMinimalistic = IconData(0xece9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const notes = IconData(0xecea, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const documentAdd = IconData(0xeceb, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const documentMedicine = IconData(0xecec, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const documentText = IconData(0xeced, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const document1 = IconData(0xecee, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const documents = IconData(0xecef, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const codeScan = IconData(0xecf0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const eyeScan = IconData(0xecf1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const objectScan = IconData(0xecf2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const qrCode = IconData(0xecf3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const scanner_2 = IconData(0xecf4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const scanner = IconData(0xecf5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const shieldCheck = IconData(0xecf6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const shieldCross = IconData(0xecf7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const shieldKeyholeMinimalistic = IconData(0xecf8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const shieldKeyhole = IconData(0xecf9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const shieldMinus = IconData(0xecfa, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const shieldNetwork = IconData(0xecfb, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const shieldPlus = IconData(0xecfc, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const shieldStar = IconData(0xecfd, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const shieldUp = IconData(0xecfe, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const shieldUser = IconData(0xecff, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const shieldWarning = IconData(0xed00, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bombEmoji = IconData(0xed01, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bombMinimalistic = IconData(0xed02, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bomb = IconData(0xed03, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const eyeClosed = IconData(0xed04, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const eye = IconData(0xed05, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const incognito = IconData(0xed06, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const keyMinimalistic2 = IconData(0xed07, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const keyMinimalisticSquare_2 = IconData(0xed08, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const keyMinimalisticSquare_3 = IconData(0xed09, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const keyMinimalisticSquare = IconData(0xed0a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const keyMinimalistic = IconData(0xed0b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const keySquare_2 = IconData(0xed0c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const keySquare = IconData(0xed0d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const key = IconData(0xed0e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const lockKeyholeMinimalisticUnlocked = IconData(0xed0f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const lockKeyholeMinimalistic = IconData(0xed10, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const lockKeyholeUnlocked = IconData(0xed11, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const lockKeyhole = IconData(0xed12, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const lockPassword_ = IconData(0xed13, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const lockPassword = IconData(0xed14, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const lockUnlocked = IconData(0xed15, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const lock = IconData(0xed16, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const passwordMinimalisticInput = IconData(0xed17, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const passwordMinimalistic = IconData(0xed18, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const password = IconData(0xed19, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const shieldMinimalistic = IconData(0xed1a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const shield = IconData(0xed1b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sirenRounded = IconData(0xed1c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const siren = IconData(0xed1d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const boltCircle = IconData(0xed1e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bolt = IconData(0xed1f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const confettiMinimalistic = IconData(0xed20, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const confetti = IconData(0xed21, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const maskHapply = IconData(0xed22, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const masks = IconData(0xed23, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mentionCircle = IconData(0xed24, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mentionSquare = IconData(0xed25, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const trashBin2 = IconData(0xed26, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const trashBinTrash = IconData(0xed27, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const accessibility = IconData(0xed28, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const body = IconData(0xed29, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const boxMinimalistic = IconData(0xed2a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const box = IconData(0xed2b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cosmetic = IconData(0xed2c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cursorSquare = IconData(0xed2d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cursor = IconData(0xed2e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const delivery = IconData(0xed2f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const feed = IconData(0xed30, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const ferrisWheel = IconData(0xed31, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const flashlightOn = IconData(0xed32, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const flashlight = IconData(0xed33, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const gift = IconData(0xed34, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const hanger_2 = IconData(0xed35, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const hanger = IconData(0xed36, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const magicStick_2 = IconData(0xed37, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const magicStick_3 = IconData(0xed38, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const magicStick = IconData(0xed39, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const magnetWave = IconData(0xed3a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const magnet = IconData(0xed3b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const maskSad = IconData(0xed3c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const mirror1 = IconData(0xed3d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const perfume = IconData(0xed3e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const scissorsSquare = IconData(0xed3f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const skirt = IconData(0xed40, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sledgehammer = IconData(0xed41, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sleeping = IconData(0xed42, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const tShirt = IconData(0xed43, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const k = IconData(0xed44, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const augmentedReality = IconData(0xed45, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const balloon = IconData(0xed46, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const copyright = IconData(0xed47, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const creativeCommons = IconData(0xed48, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cupFirst = IconData(0xed49, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cupMusic = IconData(0xed4a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cupStar = IconData(0xed4b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cup1 = IconData(0xed4c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const explicit = IconData(0xed4d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const figma = IconData(0xed4e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const filter = IconData(0xed4f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const flag_2 = IconData(0xed50, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const flag = IconData(0xed51, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const fuel = IconData(0xed52, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const glasses = IconData(0xed53, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const hamburgerMenu = IconData(0xed54, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const help = IconData(0xed55, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const highDefinition = IconData(0xed56, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const highQuality = IconData(0xed57, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const paperBin = IconData(0xed58, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const paw = IconData(0xed59, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const power = IconData(0xed5a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const reorder1 = IconData(0xed5b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const scissors = IconData(0xed5c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sort = IconData(0xed5d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const specialEffects = IconData(0xed5e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const winRar = IconData(0xed5f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const xxx = IconData(0xed60, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const broom = IconData(0xed61, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const cat = IconData(0xed62, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const copy = IconData(0xed63, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const crownLine = IconData(0xed64, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const crownMinimalistic = IconData(0xed65, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const crownStar = IconData(0xed66, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const crown = IconData(0xed67, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const database = IconData(0xed68, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const ghostSmile = IconData(0xed69, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const ghost = IconData(0xed6a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const pinCircle = IconData(0xed6b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const pinList = IconData(0xed6d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const pin = IconData(0xed6e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const plate = IconData(0xed6f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const postsCarouselHorizontal = IconData(0xed70, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const postsCarouselVertical = IconData(0xed71, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const shareCircle = IconData(0xed72, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const share = IconData(0xed73, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sliderMinimalisticHorizontal = IconData(0xed74, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const subtitles = IconData(0xed75, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const target = IconData(0xed76, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const trafficEconomy = IconData(0xed77, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const traffic = IconData(0xed78, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const trashBinMinimalistic_2 = IconData(0xed79, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const trashBinMinimalistic = IconData(0xed7a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const umbrella = IconData(0xed7b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const waterdrop = IconData(0xed7c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const batteryChargeMinimalistic = IconData(0xed7d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const batteryCharge = IconData(0xed7e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const batteryFullMinimalistic = IconData(0xed7f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const batteryFull = IconData(0xed80, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const batteryHalfMinimalistic = IconData(0xed81, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const batteryHalf = IconData(0xed82, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const batteryLowMinimalistic = IconData(0xed83, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const batteryLow = IconData(0xed84, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const home2 = IconData(0xed85, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const homeAddAngle = IconData(0xed86, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const homeAdd = IconData(0xed87, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const homeAngle_2 = IconData(0xed88, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const homeAngle = IconData(0xed89, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const homeSmileAngle = IconData(0xed8a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const homeSmile = IconData(0xed8b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const homeWiFiAngle = IconData(0xed8c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const homeWiFi = IconData(0xed8d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const home = IconData(0xed8e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const infoSquare = IconData(0xed8f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const menuDotsCircle = IconData(0xed90, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const menuDotsSquare = IconData(0xed91, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const menuDots = IconData(0xed92, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const minusSquare = IconData(0xed93, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const revote = IconData(0xed94, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sliderHorizontal = IconData(0xed95, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sliderVerticalMinimalistic = IconData(0xed96, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const sliderVertical = IconData(0xed97, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const smartHomeAngle = IconData(0xed98, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const smartHome = IconData(0xed99, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const addCircle = IconData(0xed9a, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const addSquare = IconData(0xed9b, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const checkCircle = IconData(0xed9c, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const checkSquare = IconData(0xed9d, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const closeCircle = IconData(0xed9e, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const closeSquare = IconData(0xed9f, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const dangerCircle = IconData(0xeda0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const dangerSquare = IconData(0xeda1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const dangerTriangle = IconData(0xeda2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const danger = IconData(0xeda3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const forbiddenCircle = IconData(0xeda4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const forbidden = IconData(0xeda5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const infoCircle = IconData(0xeda6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const minusCircle = IconData(0xeda7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const questionCircle = IconData(0xeda8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const questionSquare = IconData(0xeda9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const userHandUp = IconData(0xedaa, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const userHands = IconData(0xedab, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const userHeart = IconData(0xedac, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const userBlockRounded = IconData(0xedad, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const userBlock = IconData(0xedae, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const userCheckRounded = IconData(0xedaf, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const userCheck = IconData(0xedb0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const userCircle = IconData(0xedb1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const userCrossRounded = IconData(0xedb2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const userCross = IconData(0xedb3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const userHeartRounded = IconData(0xedb4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const userId = IconData(0xedb5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const userMinusRounded = IconData(0xedb6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const userMinus = IconData(0xedb7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const userPlusRounded = IconData(0xedb8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const userPlus = IconData(0xedb9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const userRounded = IconData(0xedba, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const userSpeakRounded = IconData(0xedbb, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const userSpeak = IconData(0xedbc, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const user = IconData(0xedbd, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const usersGroupRounded = IconData(0xedbe, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const usersGroupTwoRounded = IconData(0xedbf, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const handHeart = IconData(0xedc0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const handMoney = IconData(0xedc1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const handPills = IconData(0xedc2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const handShake = IconData(0xedc3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const handStars = IconData(0xedc4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const buildings_2 = IconData(0xedc5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const buildings_3 = IconData(0xedc6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const buildings = IconData(0xedc7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const city = IconData(0xedc8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const garage = IconData(0xedc9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const home1 = IconData(0xedca, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const hospital = IconData(0xedcb, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const kickScooter = IconData(0xedcc, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const scooter = IconData(0xedcd, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const speedometerLow = IconData(0xedce, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const speedometerMax = IconData(0xedcf, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const speedometerMiddle = IconData(0xedd0, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const wheelAngle = IconData(0xedd1, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const wheel = IconData(0xedd2, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const accumulator = IconData(0xedd3, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const bus = IconData(0xedd4, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const electricRefueling = IconData(0xedd5, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const gasStation = IconData(0xedd6, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const shockAbsorber = IconData(0xedd7, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const suspensionBolt = IconData(0xedd8, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const suspensionCross = IconData(0xedd9, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const suspension = IconData(0xedda, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const tram = IconData(0xeddb, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const transmissionCircle = IconData(0xeddc, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const transmissionSquare = IconData(0xeddd, fontFamily: _fontFamily, fontPackage: 'solar_icons');
+  static const transmission = IconData(0xedde, fontFamily: _fontFamily, fontPackage: 'solar_icons');
 }

--- a/test/solar_icons_test.dart
+++ b/test/solar_icons_test.dart
@@ -1,11 +1,13 @@
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:solar_icons/solar_icons.dart';
 
 void main() {
   group(SolarIconsBold, () {
     test('Test bold icons are generated', () {
-      String fontFamily = 'SolarIconsBold';
-      SolarIconsData icon = SolarIconsData(0xe900, fontFamily: fontFamily);
+      const fontFamily = 'SolarIconsBold';
+      const icon = IconData(0xe900, fontFamily: fontFamily);
+
       expect(icon, equals(SolarIconsBold.forward));
       expect(icon.codePoint, 0xe900);
       expect(icon.fontFamily, SolarIconsBold.forward.fontFamily);
@@ -14,8 +16,8 @@ void main() {
 
   group(SolarIconsOutline, () {
     test('Test that outline icons are generated', () {
-      String fontFamily = 'SolarIconsOutline';
-      SolarIconsData icon = SolarIconsData(0xe900, fontFamily: fontFamily);
+      const fontFamily = 'SolarIconsOutline';
+      const icon = IconData(0xe900, fontFamily: fontFamily);
       expect(icon, equals(SolarIconsOutline.forward));
       expect(icon.codePoint, 0xe900);
       expect(icon.fontFamily, SolarIconsOutline.forward.fontFamily);
@@ -24,8 +26,8 @@ void main() {
 
   group(SolarIconsBroken, () {
     test('Test that broken icons are generated', () {
-      String fontFamily = 'SolarIconsBroken';
-      SolarIconsData icon = SolarIconsData(0xe900, fontFamily: fontFamily);
+      const fontFamily = 'SolarIconsBroken';
+      const icon = IconData(0xe900, fontFamily: fontFamily);
       expect(icon, equals(SolarIconsBroken.multipleForwardLeft));
       expect(icon.codePoint, 0xe900);
       expect(icon.fontFamily, SolarIconsBroken.multipleForwardLeft.fontFamily);


### PR DESCRIPTION
Reason: From Flutter 3.44 onwards, `IconData` class has been marked as final.

More info here:
https://docs.flutter.dev/release/breaking-changes/icondata-class-marked-final
https://github.com/flutter/flutter/issues/181342